### PR TITLE
Use NULL: true when no company_name

### DIFF
--- a/services/bots/src/cla-sign/cla-sign.service.ts
+++ b/services/bots/src/cla-sign/cla-sign.service.ts
@@ -56,7 +56,7 @@ export class ClaSignService {
           TableName: this.signersTableName,
           Item: {
             github_username: { S: signData.github_username },
-            company_name: { S: signData.company_name || '' },
+            company_name: signData.company_name ? { S: signData.company_name } : { NULL: true },
             country: { S: signData.country },
             email: { S: signData.email },
             github_user_id: { S: signData.github_user_id },


### PR DESCRIPTION
INstead of storing a blank value we store null if there is no company name