### PR TITLE
Limit docs_parenting and hacktoberfest

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.const.ts
+++ b/services/bots/src/github-webhook/github-webhook.const.ts
@@ -19,6 +19,7 @@ export enum Repository {
   BRANDS = 'brands',
   CORE = 'core',
   DEVELOPERS_HOME_ASSISTANT = 'developers.home-assistant',
+  FRONTEND = 'frontend',
   HOME_ASSISTANT_IO = 'home-assistant.io',
 }
 

--- a/services/bots/src/github-webhook/handlers/docs_parenting.ts
+++ b/services/bots/src/github-webhook/handlers/docs_parenting.ts
@@ -27,7 +27,10 @@ export class DocsParenting extends BaseWebhookHandler {
         'pull_request.closed',
         'pull_request.opened',
         'pull_request.edited',
-      ].includes(context.eventType)
+      ].includes(context.eventType) ||
+      ![Repository.CORE, Repository.HOME_ASSISTANT_IO, Repository.FRONTEND].includes(
+        context.repo().repo as Repository,
+      )
     ) {
       return;
     }

--- a/services/bots/src/github-webhook/handlers/hacktoberfest.ts
+++ b/services/bots/src/github-webhook/handlers/hacktoberfest.ts
@@ -1,4 +1,5 @@
 import { PullRequestClosedEvent } from '@octokit/webhooks-types';
+import { Repository } from '../github-webhook.const';
 import { WebhookContext } from '../github-webhook.model';
 import { BaseWebhookHandler } from './base';
 
@@ -6,6 +7,13 @@ export const isHacktoberfestLive = () => new Date().getMonth() === 9;
 
 export class Hacktoberfest extends BaseWebhookHandler {
   async handle(context: WebhookContext<any>) {
+    if (
+      ![Repository.CORE, Repository.HOME_ASSISTANT_IO, Repository.FRONTEND].includes(
+        context.repo().repo as Repository,
+      )
+    ) {
+      return;
+    }
     if (isHacktoberfestLive && context.eventType === 'pull_request.opened') {
       await this.handlePullRequestOpened(context);
     } else if (context.eventType === 'pull_request.closed') {


### PR DESCRIPTION
This is to match the repositories that currently have probot active.
We can always extend in the future, but that should not be now when switching the source.