### PR TITLE
Make hacktoberfest handler dynamic

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.const.ts
+++ b/services/bots/src/github-webhook/github-webhook.const.ts
@@ -19,11 +19,20 @@ export type GetIssueLabelResponse =
   RestEndpointMethodTypes['issues']['getLabel']['response']['data'];
 
 export enum Repository {
+  ADDONS = 'addons',
+  ANDROID = 'android',
   BRANDS = 'brands',
+  CLI = 'cli',
+  COMPANION_HOME_ASSISTANT = 'companion.home-assistant',
   CORE = 'core',
   DEVELOPERS_HOME_ASSISTANT = 'developers.home-assistant',
   FRONTEND = 'frontend',
   HOME_ASSISTANT_IO = 'home-assistant.io',
+  IOS = 'iOS',
+  OPERATING_SYSTEM = 'operating-system',
+  SERVICE_HUB = 'service-hub',
+  SUPERVISED_INSTALLER = 'supervised-installer',
+  SUPERVISOR = 'supervisor',
 }
 
 export enum EventType {

--- a/services/bots/src/github-webhook/handlers/base.ts
+++ b/services/bots/src/github-webhook/handlers/base.ts
@@ -6,7 +6,7 @@ import { WebhookContext } from '../github-webhook.model';
 export class BaseWebhookHandler {
   public allowBots: boolean = true;
   public allowedEventTypes: EventType[] = [];
-  public allowedRepositories: Repository[] = Object.values(Repository);
+  public allowedRepositories: Repository[] = [];
 
   constructor() {
     WEBHOOK_HANDLERS.push(this);

--- a/services/bots/src/github-webhook/handlers/hacktoberfest.ts
+++ b/services/bots/src/github-webhook/handlers/hacktoberfest.ts
@@ -23,10 +23,6 @@ export class Hacktoberfest extends BaseWebhookHandler {
     context.scheduleIssueLabel('Hacktoberfest');
   }
   async handlePullRequestClosed(context: WebhookContext<PullRequestClosedEvent>) {
-    if (!context.payload.repository?.topics?.includes('hacktoberfest')) {
-      return;
-    }
-
     const pullRequest = context.payload.pull_request;
 
     // Don't do something if the PR got merged or if it had no Hacktoberfest label.

--- a/services/bots/src/github-webhook/handlers/month_of_wth.ts
+++ b/services/bots/src/github-webhook/handlers/month_of_wth.ts
@@ -10,7 +10,6 @@ const WTH_CATEGORY_ID = 56;
 
 export class MonthOfWTH extends BaseWebhookHandler {
   public allowedEventTypes = [EventType.PULL_REQUEST_OPENED];
-  public allowedRepositories = [];
 
   async handle(context: WebhookContext<PullRequestOpenedEvent>) {
     for (const link of extractForumLinks((context.payload.pull_request as PullRequest).body)) {

--- a/tests/services/bots/github-webhook/handlers/hacktoberfest.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/hacktoberfest.spec.ts
@@ -51,6 +51,7 @@ describe('Hacktoberfest', () => {
 
   it('Add hacktoberfest label on new PR', async () => {
     const clock = sinon.useFakeTimers(new Date(2020, 9, 1).getTime());
+    mockContext.payload.repository = { topics: ['hacktoberfest'] };
     await handler.handle(mockContext);
     clock.restore();
 


### PR DESCRIPTION
Instead of hardcoding these, we check the "repository" part of the webhook payload to determine if we should run or not.

This way a repository only needs to add the "hacktoberfest" topic to enable this handler.
<https://github.com/orgs/home-assistant/repositories?q=hacktoberfest&type=all>