### PR TITLE
Use "core" directly

### DIFF
--- a/services/bots/src/github-webhook/handlers/set_integration.ts
+++ b/services/bots/src/github-webhook/handlers/set_integration.ts
@@ -18,7 +18,7 @@ export class SetIntegration extends BaseWebhookHandler {
     )) {
       const label = `integration: ${link.integration}`;
       const exist = await context.github.issuesGetLabel(
-        context.issue({ name: label, repo: HomeAssistantRepository.CORE }),
+        context.issue({ name: label, repo: 'core' }),
       );
       if (exist?.name === label) {
         context.scheduleIssueLabel(label);


### PR DESCRIPTION
`HomeAssistantRepository.CORE` now returns `home-assistant/core` but here we only want "core"