### PR TITLE
Run DocsMissing when pull request are edited

### DIFF
--- a/services/bots/src/github-webhook/handlers/docs_missing.ts
+++ b/services/bots/src/github-webhook/handlers/docs_missing.ts
@@ -13,6 +13,7 @@ import { BaseWebhookHandler } from './base';
 
 export class DocsMissing extends BaseWebhookHandler {
   public allowedEventTypes = [
+    EventType.PULL_REQUEST_EDITED,
     EventType.PULL_REQUEST_LABELED,
     EventType.PULL_REQUEST_UNLABELED,
     EventType.PULL_REQUEST_SYNCHRONIZE,


### PR DESCRIPTION
Since there are a spot to add doc link in the description, it make sense to run this when the PR is edited as well