### PR TITLE
Add CodeOwnerCommands

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.const.ts
+++ b/services/bots/src/github-webhook/github-webhook.const.ts
@@ -40,6 +40,7 @@ export enum HomeAssistantRepository {
 }
 
 export enum EventType {
+  ISSUE_COMMENT_CREATED = 'issue_comment.created',
   ISSUES_LABELED = 'issues.labeled',
   ISSUES_OPENED = 'issues.opened',
   PULL_REQUEST_CLOSED = 'pull_request.closed',

--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -7,6 +7,7 @@ import { AppConfig } from '../config';
 import { GithubWebhookController } from './github-webhook.controller';
 import { BranchLabels } from './handlers/branch_labels';
 import { CodeOwnersMention } from './handlers/code_owners_mention';
+import { CodeOwnerCommands } from './handlers/code_owner_commands';
 import { DependencyBump } from './handlers/dependency_bump';
 import { DocsMissing } from './handlers/docs_missing';
 import { DocsParenting } from './handlers/docs_parenting';
@@ -25,6 +26,7 @@ import { ValidateCla } from './handlers/validate-cla';
 @Module({
   providers: [
     BranchLabels,
+    CodeOwnerCommands,
     CodeOwnersMention,
     DependencyBump,
     DocsMissing,

--- a/services/bots/src/github-webhook/handlers/code_owner_commands.ts
+++ b/services/bots/src/github-webhook/handlers/code_owner_commands.ts
@@ -1,0 +1,85 @@
+import { IssueCommentCreatedEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { fetchIntegrationManifest } from '../utils/integration';
+import { BaseWebhookHandler } from './base';
+
+export const CODE_OWNER_COMMANDS: {
+  [command: string]: {
+    description: string;
+    handler: (context: WebhookContext<IssueCommentCreatedEvent>) => Promise<void>;
+  };
+} = {
+  '/close': {
+    description: 'Closes the issue.',
+    handler: async (context: WebhookContext<IssueCommentCreatedEvent>) => {
+      await context.github.issues.update(
+        context.issue({
+          state: 'closed',
+        }),
+      );
+    },
+  },
+  '/rename': {
+    description: 'Change the title of the issue.',
+    handler: async (context: WebhookContext<IssueCommentCreatedEvent>) => {
+      await context.github.issues.update(
+        context.issue({
+          title: context.payload.comment.body.replace('/rename ', ''),
+        }),
+      );
+    },
+  },
+  '/unassign': {
+    description: 'Removes the current integration label and assignees on the issue.',
+    handler: async (context: WebhookContext<IssueCommentCreatedEvent>) => {
+      await context.github.issues.removeLabel(
+        context.issue({
+          name: context.payload.issue.labels.find((label) =>
+            label.name.startsWith('integration: '),
+          )[0].name,
+        }),
+      );
+      await context.github.issues.removeAssignees(
+        context.issue({
+          assignees: context.payload.issue.assignees.map((user) => user.login),
+        }),
+      );
+    },
+  },
+};
+
+export class CodeOwnerCommands extends BaseWebhookHandler {
+  public allowedEventTypes = [EventType.ISSUE_COMMENT_CREATED];
+  public allowedRepositories = [
+    HomeAssistantRepository.CORE,
+    HomeAssistantRepository.HOME_ASSISTANT_IO,
+  ];
+
+  async handle(context: WebhookContext<IssueCommentCreatedEvent>) {
+    const input = context.payload.comment.body?.trim().split(' ')[0];
+    const currentLabels = context.payload.issue.labels
+      .map((label) => label.name)
+      .filter((label) => label.startsWith('integration: '));
+    const command = CODE_OWNER_COMMANDS[input];
+    if (!command || currentLabels.length !== 1) {
+      // Return if there is no known command or if there is no integration label or if there are multiple integration labels
+      return;
+    }
+
+    const integrationManifest = await fetchIntegrationManifest(
+      currentLabels[0].split('integration: ')[1],
+    );
+
+    if (!integrationManifest.codeowners?.includes(`@${context.payload.comment.user.login}`)) {
+      // Return if the user is not a code owner
+      return;
+    }
+
+    await context.github.reactions.createForIssueComment(
+      context.repo({ comment_id: context.payload.comment.id, content: '+1' }),
+    );
+
+    await command.handler(context);
+  }
+}

--- a/services/bots/src/github-webhook/handlers/code_owner_commands.ts
+++ b/services/bots/src/github-webhook/handlers/code_owner_commands.ts
@@ -7,6 +7,7 @@ import { BaseWebhookHandler } from './base';
 export const CODE_OWNER_COMMANDS: {
   [command: string]: {
     description: string;
+    example?: string;
     handler: (context: WebhookContext<IssueCommentCreatedEvent>) => Promise<void>;
   };
 } = {
@@ -22,6 +23,7 @@ export const CODE_OWNER_COMMANDS: {
   },
   '/rename': {
     description: 'Change the title of the issue.',
+    example: '/rename Awesome new title',
     handler: async (context: WebhookContext<IssueCommentCreatedEvent>) => {
       const title = context.payload.comment.body.split('/rename ')[1];
       if (title) {

--- a/services/bots/src/github-webhook/handlers/code_owners_mention.ts
+++ b/services/bots/src/github-webhook/handlers/code_owners_mention.ts
@@ -5,6 +5,7 @@ import { issueFromPayload } from '../utils/issue';
 import { BaseWebhookHandler } from './base';
 
 import { CodeOwnersEntry, matchFile } from 'codeowners-utils';
+import { CODE_OWNER_COMMANDS } from './code_owner_commands';
 
 export class CodeOwnersMention extends BaseWebhookHandler {
   public allowedEventTypes = [EventType.ISSUES_LABELED, EventType.PULL_REQUEST_LABELED];
@@ -84,7 +85,27 @@ export class CodeOwnersMention extends BaseWebhookHandler {
         handler: 'CodeOwnersMention',
         comment: `Hey there ${mentions.join(
           ', ',
-        )}, mind taking a look at this ${triggerLabel} as it has been labeled with an integration (\`${integrationName}\`) you are listed as a [code owner](${codeownersLine}) for? Thanks!`,
+        )}, mind taking a look at this ${triggerLabel} as it has been labeled with an integration (\`${integrationName}\`) you are listed as a [code owner](${codeownersLine}) for? Thanks!
+        ${
+          mentions.length === 1
+            ? `
+
+        <details>
+          <summary>Code owner comands</summary>
+
+          Code owners of \`${integrationName}\` can use these commands to help triage issues:
+
+          Command | Description
+          --- | ---
+          ${Object.entries(CODE_OWNER_COMMANDS)
+            .map(([command, data]) => `- \`${command}\` | ${data.description}`)
+            .join('\n')}
+
+        </details>
+
+        `
+            : ''
+        }`,
         priority: 1,
       });
     }

--- a/services/bots/src/github-webhook/handlers/code_owners_mention.ts
+++ b/services/bots/src/github-webhook/handlers/code_owners_mention.ts
@@ -95,10 +95,13 @@ export class CodeOwnersMention extends BaseWebhookHandler {
 
           Code owners of \`${integrationName}\` can use these commands to help triage issues:
 
-          Command | Description
-          --- | ---
+          Command | Example | Description
+          --- | --- | ---
           ${Object.entries(CODE_OWNER_COMMANDS)
-            .map(([command, data]) => `- \`${command}\` | ${data.description}`)
+            .map(
+              ([command, data]) =>
+                `- \`${command}\` | \`${data.example || command} }\` | ${data.description}`,
+            )
             .join('\n')}
 
         </details>


### PR DESCRIPTION
This adds commands to GitHub issues for integration code owners.

A Code owner can with this (if there is only 1 integration labeled):

- Have the bot close the issue with `/close`
- Have the bot change the title of the issue with `/rename New title here`
- Have the bot remove the integration label and assignees with  `/unassign`

These commands will be listed by `CodeownersMention` if there is only 1 code owner for that integration.