### PR TITLE
Replace domain with integration

### DIFF
--- a/services/bots/src/github-webhook/handlers/code_owners_mention.ts
+++ b/services/bots/src/github-webhook/handlers/code_owners_mention.ts
@@ -27,7 +27,7 @@ ${Object.entries(ISSUE_COMMENT_COMMANDS)
   .filter(([command, data]) => data.invokerType === 'code_owner')
   .map(
     ([command, data]) =>
-      `- \`${['@home-assistant', command, data.exampleAdditional?.replace('[domain]', integration)]
+      `- \`${['@home-assistant', command, data.exampleAdditional?.replace('<domain>', integration)]
         .filter((item) => item !== undefined)
         .join(' ')
         .trim()}\` ${data.description}`,

--- a/services/bots/src/github-webhook/handlers/code_owners_mention.ts
+++ b/services/bots/src/github-webhook/handlers/code_owners_mention.ts
@@ -20,13 +20,14 @@ Hey there ${codeOwners.join(
 <details>
 <summary>Code owner commands</summary>
 
-Code owners of \`${integration}\ can trigger bot actions by commenting:
+
+Code owners of \`${integration}\` can trigger bot actions by commenting:
 
 ${Object.entries(ISSUE_COMMENT_COMMANDS)
   .filter(([command, data]) => data.invokerType === 'code_owner')
   .map(
     ([command, data]) =>
-      `- \`${['@home-assistant', command, data.exampleAdditional]
+      `- \`${['@home-assistant', command, data.exampleAdditional?.replace('[domain]', integration)]
         .filter((item) => item !== undefined)
         .join(' ')
         .trim()}\` ${data.description}`,

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands.ts
@@ -41,7 +41,7 @@ export const ISSUE_COMMENT_COMMANDS: { [command: string]: IssueCommentCommand } 
   unassign: {
     description:
       'Removes the current integration label and assignees on the issue, add the integration domain after the command.',
-    exampleAdditional: '[domain]',
+    exampleAdditional: '<domain>',
     invokerType: 'code_owner',
     requireAdditional: true,
     handler: async (

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands.ts
@@ -41,7 +41,7 @@ export const ISSUE_COMMENT_COMMANDS: { [command: string]: IssueCommentCommand } 
   unassign: {
     description:
       'Removes the current integration label and assignees on the issue, add the integration domain after the command.',
-    exampleAdditional: 'domain',
+    exampleAdditional: '[domain]',
     invokerType: 'code_owner',
     requireAdditional: true,
     handler: async (


### PR DESCRIPTION
When using `[domain]` as the example additional description, replace it with the integration name in codeowners mention