### PR TITLE
Use uppecase for approved state match

### DIFF
--- a/services/bots/src/github-webhook/handlers/platinum_review.ts
+++ b/services/bots/src/github-webhook/handlers/platinum_review.ts
@@ -61,7 +61,7 @@ export class PlatinumReview extends BaseWebhookHandler {
         if (
           reviews.data.find(
             (review) =>
-              review.state === 'approved' && manifest.codeowners.includes(`@${review.user.login}`),
+              review.state === 'APPROVED' && manifest.codeowners.includes(`@${review.user.login}`),
           )
         ) {
           // A code owner did approve, it's done.


### PR DESCRIPTION
In the webhook payload that triggers on pull request review, the state is lowercase.
But in the API it's uppercase https://api.github.com/repos/home-assistant/core/pulls/81278/reviews

This PR changes the logic to match with uppercase.