### PR TITLE
Add the description to the integrations in home assistant bot

### DIFF
--- a/services/bots/src/discord/commands/home-assistant/integration.ts
+++ b/services/bots/src/discord/commands/home-assistant/integration.ts
@@ -67,6 +67,7 @@ export class CommandHomeassistantIntegration implements DiscordTransformedComman
       embeds: [
         new EmbedBuilder({
           title: integrationData.title,
+          description: integrationData.description,
           thumbnail: { url: `https://brands.home-assistant.io/${domain}/dark_logo.png` },
           fields: [
             {

--- a/services/bots/src/discord/services/home-assistant/integration-data.ts
+++ b/services/bots/src/discord/services/home-assistant/integration-data.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 
 export interface IntegrationData {
   title: string;
+  description: string;
   quality_scale: string;
   iot_class: string;
 }


### PR DESCRIPTION
Adding the descriptions which I PRed into the HA integrations into the `/integration` command in the bot. It's slightly more informational and helpful to new users to have a description without needing to click a link :)


P.S. sorry about the trailing line breaks being removed, I did make sure Prettier and ESLint were configured though.