### PR TITLE
Ignore PRs with multiple integrations for platinum review

### DIFF
--- a/services/bots/src/github-webhook/handlers/platinum_review.ts
+++ b/services/bots/src/github-webhook/handlers/platinum_review.ts
@@ -39,13 +39,10 @@ export class PlatinumReview extends BaseWebhookHandler {
     }
 
     const integrations = currentLabels.filter((label) => label.startsWith('integration: '));
-    if (integrations.length !== 1) {
-      // Not only one, do not proceed.
-    }
 
-    let requiresCodeownerApproval = !currentLabels.find((label) =>
-      ['by-code-owner', 'code-owner-approved'].includes(label),
-    );
+    let requiresCodeownerApproval =
+      integrations.length === 1 &&
+      !currentLabels.find((label) => ['by-code-owner', 'code-owner-approved'].includes(label));
 
     if (requiresCodeownerApproval) {
       const manifest = await fetchIntegrationManifest(integrations[0].substring(13));


### PR DESCRIPTION
Ref: https://github.com/home-assistant/core/pull/81783
This makes sure we do not set failing status on PRs that contain multiple integrations.

Later we would want to expand on this handler to check that _all_ platinum integrations in a PR are approved by a code owner of that integration.