### PR TITLE
Throw http exception for request errors in cla sign

### DIFF
--- a/services/bots/src/cla-sign/cla-sign.controller.ts
+++ b/services/bots/src/cla-sign/cla-sign.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Post, Headers } from '@nestjs/common';
-import { ClaSignService } from './cla-sign.service';
+import { Body, Controller, Post, Headers, HttpException } from '@nestjs/common';
+import { ClaSignService, ServiceRequestError } from './cla-sign.service';
 
 @Controller('/cla-sign')
 export class ClaSignController {
@@ -10,6 +10,13 @@ export class ClaSignController {
     @Headers() headers: Record<string, any>,
     @Body() payload: Record<string, any>,
   ): Promise<void> {
-    await this.claSignService.handleClaSignature(headers, payload);
+    try {
+      await this.claSignService.handleClaSignature(headers, payload);
+    } catch (e) {
+      if (e instanceof ServiceRequestError) {
+        throw new HttpException(e.message, 400);
+      }
+      throw e;
+    }
   }
 }

--- a/services/bots/src/cla-sign/cla-sign.service.ts
+++ b/services/bots/src/cla-sign/cla-sign.service.ts
@@ -6,6 +6,8 @@ import { createAppAuth } from '@octokit/auth-app';
 import { DynamoDB } from 'aws-sdk';
 import { GithubClient } from '../github-webhook/github-webhook.model';
 
+export class ServiceRequestError extends ServiceError {}
+
 @Injectable()
 export class ClaSignService {
   private githubApiClient: GithubClient;
@@ -42,7 +44,7 @@ export class ClaSignService {
 
     // Check signData
     if (!signData.github_username) {
-      throw new ServiceError('Missing required data in payload', {
+      throw new ServiceRequestError('Missing required data in payload', {
         data: { signData },
         service: 'cla-sign',
       });
@@ -58,7 +60,10 @@ export class ClaSignService {
     ).Item;
 
     if (!pendingRequest) {
-      throw new ServiceError('No pending request', { data: { signData }, service: 'cla-sign' });
+      throw new ServiceRequestError('No pending request', {
+        data: { signData },
+        service: 'cla-sign',
+      });
     }
 
     // Store signData

--- a/services/bots/src/cla-sign/cla-sign.service.ts
+++ b/services/bots/src/cla-sign/cla-sign.service.ts
@@ -60,10 +60,13 @@ export class ClaSignService {
     ).Item;
 
     if (!pendingRequest) {
-      throw new ServiceRequestError(`No pending request found for ${signData.github_username}. Are you signing the CLA with the same GitHub user that created the commits in the Pull Request?`, {
-        data: { signData },
-        service: 'cla-sign',
-      });
+      throw new ServiceRequestError(
+        `No pending request found for ${signData.github_username}. Are you signing the CLA with the same GitHub user that created the commits in the Pull Request?`,
+        {
+          data: { signData },
+          service: 'cla-sign',
+        },
+      );
     }
 
     // Store signData

--- a/services/bots/src/cla-sign/cla-sign.service.ts
+++ b/services/bots/src/cla-sign/cla-sign.service.ts
@@ -60,7 +60,7 @@ export class ClaSignService {
     ).Item;
 
     if (!pendingRequest) {
-      throw new ServiceRequestError('No pending request', {
+      throw new ServiceRequestError(`No pending request found for ${signData.github_username}. Are you signing the CLA with the same GitHub user that created the commits in the Pull Request?`, {
         data: { signData },
         service: 'cla-sign',
       });


### PR DESCRIPTION
Rethrow expected errors as HTTP Bad request, that way the messages can be shown to the user after this https://github.com/home-assistant/home-assistant.io/pull/25496