### PR TITLE
Fix Discord message for formatting code

### DIFF
--- a/data/discord/messages/common.yaml
+++ b/data/discord/messages/common.yaml
@@ -1,9 +1,9 @@
 format:
   description: "How to format text as code"
   content: >-
-    To format your text as code, enter three backticks on the first line, press
-    Enter for a new line, paste your code, press Enter again for another new
-    line, and lastly three more backticks.
+    To format your text as code, enter three backticks on the first line, press 
+    Shift+Enter for a new line, paste your code, press Enter again for another
+    new line, and lastly three more backticks.
 
     \`\`\`yaml
 


### PR DESCRIPTION
It errantly tells the user to press `Enter` to add a new line, but the default Discord settings require `Shift+Enter`.