### PR TITLE
Allow fields in messages

### DIFF
--- a/services/bots/src/discord/commands/common/message.ts
+++ b/services/bots/src/discord/commands/common/message.ts
@@ -64,6 +64,9 @@ export class CommandCommonMessage implements DiscordTransformedCommand<MessageDt
           description: [userMention, message.content].join(' '),
           title: message.title,
           image: message.image ? { url: message.image } : undefined,
+          fields: message.fields?.length
+            ? message.fields.map((field) => ({ ...field, inline: true }))
+            : undefined,
         }),
       ],
     });

--- a/services/bots/src/discord/services/common/message-data.ts
+++ b/services/bots/src/discord/services/common/message-data.ts
@@ -9,6 +9,7 @@ interface Message {
   description?: string;
   image?: string;
   title?: string;
+  fields?: { name: string; value: string }[];
 }
 
 interface MessageData {


### PR DESCRIPTION
This allow us to define `fields` for embed messages.