### PR TITLE
Remove files for dependency_bump handler

### DIFF
--- a/services/bots/src/github-webhook/handlers/dependency_bump.ts
+++ b/services/bots/src/github-webhook/handlers/dependency_bump.ts
@@ -5,8 +5,6 @@ import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
 import { BaseWebhookHandler } from './base';
 
 const DEPENDENCY_FILES = new Set([
-  'setup.py',
-  'manifest.json',
   'package_constraints.txt',
   'requirements_all.txt',
   'requirements_docs.txt',


### PR DESCRIPTION
- 'setup.py' does not exist anymore.
- 'manifest.json' will not change without the others also changing if its really a dependency-bump.

Replaces #146 
Closes #135