### PR TITLE
Add author_association filter

### DIFF
--- a/services/bots/src/github-webhook/handlers/review_drafter.ts
+++ b/services/bots/src/github-webhook/handlers/review_drafter.ts
@@ -36,9 +36,12 @@ export class ReviewDrafter extends BaseWebhookHandler {
   async handleReviewCommentSubmitted(context: WebhookContext<PullRequestReviewSubmittedEvent>) {
     if (
       context.payload.pull_request.draft ||
-      context.payload.review.state !== 'changes_requested'
+      context.payload.review.state !== 'changes_requested' ||
+      !['COLLABORATOR', 'MEMBER', 'OWNER'].includes(context.payload.review.author_association)
     ) {
-      // We only care about changes_requested on non-draft PRs
+      // If the PR is already a draft, we don't need to do anything
+      // If the review is not a changes requested, we don't need to do anything
+      // If the author is not a collaborator, member or owner, we don't need to do anything
       return;
     }
 


### PR DESCRIPTION

<https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review>
> author_associationstring Required
How the author is associated with the repository.
> Can be one of: COLLABORATOR, CONTRIBUTOR, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR, MANNEQUIN, MEMBER, NONE, OWNER