### PR TITLE
Add missing rename example

### DIFF
--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/rename.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/rename.ts
@@ -6,6 +6,7 @@ import { IssueCommentCommandBase } from './base';
 export class RenameIssueCommentCommand implements IssueCommentCommandBase {
   command = 'rename';
   description = 'Renames the issue.';
+  exampleAdditional: 'Awesome new title';
   invokerType = 'code_owner';
   requireAdditional = true;
 


### PR DESCRIPTION
This was removed in <https://github.com/home-assistant/service-hub/pull/134> but should be included.