### PR TITLE
Add NewIntegrationsHandler

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -18,12 +18,13 @@ import { IssueLinks } from './handlers/issue_links';
 import { LabelBot } from './handlers/label_bot/handler';
 import { LabelCleaner } from './handlers/label_cleaner';
 import { MonthOfWTH } from './handlers/month_of_wth';
+import { NewIntegrationsHandler } from './handlers/new_integrations';
 import { PlatinumReview } from './handlers/platinum_review';
 import { QualityScaleLabeler } from './handlers/quality_scale';
+import { ReviewDrafter } from './handlers/review_drafter';
 import { SetDocumentationSection } from './handlers/set_documentation_section';
 import { SetIntegration } from './handlers/set_integration';
 import { ValidateCla } from './handlers/validate-cla';
-import { ReviewDrafter } from './handlers/review_drafter';
 
 @Module({
   providers: [
@@ -40,6 +41,7 @@ import { ReviewDrafter } from './handlers/review_drafter';
     LabelBot,
     LabelCleaner,
     MonthOfWTH,
+    NewIntegrationsHandler,
     PlatinumReview,
     QualityScaleLabeler,
     ReviewDrafter,

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -27,7 +27,7 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     if (integrationPlatforms.length > 1) {
       await context.github.pulls.createReview(
         context.pullRequest({
-          body: '[When adding new integrations. Limit included platforms to a single platform](https://developers.home-assistant.io/docs/review-process/#home-assistant-core)',
+          body: '[When adding new integrations, limit included platforms to a single platform. Please reduce this PR to a single platform](https://developers.home-assistant.io/docs/review-process/#home-assistant-core)',
           event: 'REQUEST_CHANGES',
         }),
       );

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -6,19 +6,13 @@ import { BaseWebhookHandler } from './base';
 import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
 import { ParsedPath } from '../utils/parse_path';
 
-const REVIEW_COMMENT = `
-When adding new integrations. Limit included platforms to a single platform, use the **Ready for review** button when you are done, thanks :+1:
-
-[_Learn more about our pull request process._](https://developers.home-assistant.io/docs/review-process/#home-assistant-core)
-`;
-
 export class NewIntegrationsHandler extends BaseWebhookHandler {
   public allowedEventTypes = [EventType.PULL_REQUEST_LABELED];
   public allowedRepositories = [HomeAssistantRepository.CORE];
 
   /**
    * When a new-integration label is added, check if the PR contains multiple platforms.
-   * If so, convert the PR to a draft and request changes.
+   * If so, request changes. The ReviewDrafter will handle the rest.
    */
   async handle(context: WebhookContext<PullRequestLabeledEvent>) {
     if (context.payload.label?.name !== 'new-integration') {
@@ -33,11 +27,10 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     if (integrationPlatforms.length > 1) {
       await context.github.pulls.createReview(
         context.pullRequest({
-          body: REVIEW_COMMENT,
+          body: '[When adding new integrations. Limit included platforms to a single platform](https://developers.home-assistant.io/docs/review-process/#home-assistant-core)',
           event: 'REQUEST_CHANGES',
         }),
       );
-      await context.convertPullRequestToDraft(context.payload.pull_request.node_id);
     }
   }
 }

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -1,0 +1,43 @@
+import { PullRequestLabeledEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { BaseWebhookHandler } from './base';
+
+import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
+import { ParsedPath } from '../utils/parse_path';
+
+const REVIEW_COMMENT = `
+When adding new integrations. Limit included platforms to a single platform, use the **Ready for review** button when you are done, thanks :+1:
+
+[_Learn more about our pull request process._](https://developers.home-assistant.io/docs/review-process/#home-assistant-core)
+`;
+
+export class NewIntegrationsHandler extends BaseWebhookHandler {
+  public allowedEventTypes = [EventType.PULL_REQUEST_LABELED];
+  public allowedRepositories = [HomeAssistantRepository.CORE];
+
+  /**
+   * When a new-integration label is added, check if the PR contains multiple platforms.
+   * If so, convert the PR to a draft and request changes.
+   */
+  async handle(context: WebhookContext<PullRequestLabeledEvent>) {
+    if (context.payload.label?.name !== 'new-integration') {
+      return;
+    }
+
+    const pullRequestFiles = await fetchPullRequestFilesFromContext(context);
+    const parsed = pullRequestFiles.map((file) => new ParsedPath(file));
+
+    const integrationPlatforms = parsed.filter((path) => path.type === 'platform');
+
+    if (integrationPlatforms.length > 1) {
+      await context.github.pulls.createReview(
+        context.pullRequest({
+          body: REVIEW_COMMENT,
+          event: 'REQUEST_CHANGES',
+        }),
+      );
+      await context.convertPullRequestToDraft(context.payload.pull_request.node_id);
+    }
+  }
+}


### PR DESCRIPTION
Adds logic to the bot to enforce our requirement of a single platform when adding new integrations.