### PR TITLE
Use the proper type in code owner command descriptions

### DIFF
--- a/services/bots/src/github-webhook/handlers/code_owners_mention.ts
+++ b/services/bots/src/github-webhook/handlers/code_owners_mention.ts
@@ -33,7 +33,7 @@ ${ISSUE_COMMENT_COMMANDS.filter((command) => command.invokerType === 'code_owner
       ]
         .filter((item) => item !== undefined)
         .join(' ')
-        .trim()}\` ${command.description}`,
+        .trim()}\` ${command.description?.replace('<type>', triggerLabel)}`,
   )
   .join('\n')}
 

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/close.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/close.ts
@@ -5,7 +5,7 @@ import { IssueCommentCommandBase } from './base';
 
 export class CloseIssueCommentCommand extends IssueCommentCommandBase {
   command = 'close';
-  description = 'Closes the issue.';
+  description = 'Closes the <type>.';
   invokerType = 'code_owner';
 
   async handle(

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/rename.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/rename.ts
@@ -5,7 +5,7 @@ import { IssueCommentCommandBase } from './base';
 
 export class RenameIssueCommentCommand implements IssueCommentCommandBase {
   command = 'rename';
-  description = 'Renames the issue.';
+  description = 'Renames the <type>.';
   exampleAdditional = 'Awesome new title';
   invokerType = 'code_owner';
   requireAdditional = true;

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/reopen.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/reopen.ts
@@ -5,7 +5,7 @@ import { IssueCommentCommandBase } from './base';
 
 export class ReopenIssueCommentCommand implements IssueCommentCommandBase {
   command = 'reopen';
-  description = 'Reopen the issue.';
+  description = 'Reopen the <type>.';
   invokerType = 'code_owner';
 
   async handle(

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/unassign.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/unassign.ts
@@ -6,7 +6,7 @@ import { IssueCommentCommandBase } from './base';
 export class UnassignIssueCommentCommand implements IssueCommentCommandBase {
   command = 'unassign';
   description =
-    'Removes the current integration label and assignees on the issue, add the integration domain after the command.';
+    'Removes the current integration label and assignees on the <type>, add the integration domain after the command.';
   exampleAdditional = '<domain>';
   invokerType = 'code_owner';
   requireAdditional = true;


### PR DESCRIPTION
Currently, we always use "Issue". This makes it better fit the context.