### PR TITLE
Check for docs on 'new-feature' PRs

### DIFF
--- a/services/bots/src/github-webhook/handlers/docs_missing.ts
+++ b/services/bots/src/github-webhook/handlers/docs_missing.ts
@@ -31,7 +31,9 @@ export class DocsMissing extends BaseWebhookHandler {
 
     if (
       !needsDocumentation &&
-      (currentLabels.has('new-integration') || currentLabels.has('new-platform'))
+      (currentLabels.has('new-integration') ||
+       currentLabels.has('new-platform') ||
+       currentLabels.has('new-feature'))
     ) {
       const linksToDocs = extractIssuesOrPullRequestMarkdownLinks(context.payload.pull_request.body)
         .concat(extractPullRequestURLLinks(context.payload.pull_request.body))


### PR DESCRIPTION
[One of my PRs](https://github.com/home-assistant/core/pull/89011) is stuck with a `docs-missing` label even though they've been added.  I think this is because the PR is labeled `new-feature` instead of `new-integration` or `new-platform`, which causes the check not to consider whether there is a docs link.