### PR TITLE
Force lowercase when checking reviewer

### DIFF
--- a/services/bots/src/github-webhook/handlers/platinum_review.ts
+++ b/services/bots/src/github-webhook/handlers/platinum_review.ts
@@ -55,7 +55,9 @@ export class PlatinumReview extends BaseWebhookHandler {
 
         if (
           reviews.data.find(
-            (review) => review.state === 'APPROVED' && expandedOwners.includes(review.user.login),
+            (review) =>
+              review.state === 'APPROVED' &&
+              expandedOwners.includes(review.user.login.toLowerCase()),
           )
         ) {
           // A code owner did approve, it's done.


### PR DESCRIPTION
The `expandOrganizationTeams` helper returns a list of forced lowercase users.
We need to force lowercase to check it.