### PR TITLE
Change name to file without space

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = function (options) {
+    return {
+        ...options,
+        devtool: 'source-map',
+    };
+};

--- a/webpack.config.js 
+++ b/webpack.config.js 
@@ -1,6 +1,0 @@
-module.exports = function (options) {
-  return {
-    ...options,
-    devtool: 'source-map',
-  };
-};


### PR DESCRIPTION
Apparently, the old file was called `webpack.config.js ` instead of `webpack.config.js`. That tiny space messed up my git.