### PR TITLE
Remove node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "graphql": "^16.6.0",
     "js-yaml": "^4.1.0",
     "nestjs-pino": "^3.1.1",
-    "node-fetch": "2",
     "pino": "^8.4.2",
     "pino-http": "^7.0.0",
     "pino-pretty": "^9.1.0",

--- a/services/bots/src/cla-sign/cla-sign.service.ts
+++ b/services/bots/src/cla-sign/cla-sign.service.ts
@@ -4,7 +4,6 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createAppAuth } from '@octokit/auth-app';
 import { DynamoDB } from 'aws-sdk';
-import fetch from 'node-fetch';
 import { GithubClient } from '../github-webhook/github-webhook.model';
 
 export class ServiceRequestError extends ServiceError {}

--- a/services/bots/src/discord/commands/home-assistant/versions.ts
+++ b/services/bots/src/discord/commands/home-assistant/versions.ts
@@ -1,6 +1,3 @@
-import fetch from 'node-fetch';
-
-import { getVersionInfo } from '@lib/common';
 import { EmbedBuilder } from 'discord.js';
 import { CommandHandler, DiscordCommandClass } from '../../discord.decorator';
 import {

--- a/services/bots/src/discord/services/common/message-data.ts
+++ b/services/bots/src/discord/services/common/message-data.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import yaml from 'js-yaml';
 
 import { Injectable } from '@nestjs/common';

--- a/services/bots/src/discord/services/esphome/component-data.ts
+++ b/services/bots/src/discord/services/esphome/component-data.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { Injectable } from '@nestjs/common';
 
 export interface ComponentData {

--- a/services/bots/src/discord/services/home-assistant/integration-data.ts
+++ b/services/bots/src/discord/services/home-assistant/integration-data.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { Injectable } from '@nestjs/common';
 
 export interface IntegrationData {

--- a/services/bots/src/discord/services/home-assistant/my-redirect-data.ts
+++ b/services/bots/src/discord/services/home-assistant/my-redirect-data.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { Injectable } from '@nestjs/common';
 
 interface Redirect {

--- a/services/bots/src/github-webhook/handlers/month_of_wth.ts
+++ b/services/bots/src/github-webhook/handlers/month_of_wth.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 import { PullRequest, PullRequestOpenedEvent } from '@octokit/webhooks-types';
 import { EventType, Organization } from '../github-webhook.const';
 import { WebhookContext } from '../github-webhook.model';

--- a/services/bots/src/github-webhook/utils/integration.ts
+++ b/services/bots/src/github-webhook/utils/integration.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 export enum QualityScale {
   NO_SCORE = 'no score',
   SILVER = 'silver',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,7 +7093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -8223,7 +8223,6 @@ __metadata:
     jest: ^29.2.1
     js-yaml: ^4.1.0
     nestjs-pino: ^3.1.1
-    node-fetch: 2
     pino: ^8.4.2
     pino-http: ^7.0.0
     pino-pretty: ^9.1.0


### PR DESCRIPTION
NodeJS now ships with `fetch` on the global namespace. https://nodejs.org/docs/latest-v20.x/api/globals.html

So, there is no reason to keep this package as a dependency anymore.