### PR TITLE
Remove "Shift+" from code format message

### DIFF
--- a/data/discord/messages/common.yaml
+++ b/data/discord/messages/common.yaml
@@ -2,7 +2,7 @@ format:
   description: "How to format text as code"
   content: >-
     To format your text as code, enter three backticks on the first line, press 
-    Shift+Enter for a new line, paste your code, press Enter again for another
+    Enter for a new line, paste your code, press Enter again for another
     new line, and lastly three more backticks.
 
     \`\`\`yaml


### PR DESCRIPTION
`Shift` is not required as discord knows not to send the message when the cursor is after a single set of \`\`\`