### PR TITLE
Fix test after early merge

### DIFF
--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -124,7 +124,7 @@ describe('GithubWebhookModule', () => {
     },
     {
       eventType: EventType.PULL_REQUEST_OPENED,
-      handlers: ['Hacktoberfest'],
+      handlers: [],
       payload: {
         repository: { full_name: 'esphome/esphome', owner: { login: 'esphome' } },
       },


### PR DESCRIPTION
Because of #228, #227 should have gotten this change before merging.
Tests are currently failing <https://github.com/home-assistant/service-hub/actions/runs/7260666997/job/19780264822>