### PR TITLE
Add set of ignored events

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.service.ts
+++ b/services/bots/src/github-webhook/github-webhook.service.ts
@@ -7,6 +7,8 @@ import { EventType, WEBHOOK_HANDLERS } from './github-webhook.const';
 import { GithubClient, WebhookContext } from './github-webhook.model';
 import { uniqueEntries } from './utils/list';
 
+const ignoredEventActions = new Set(['new_permissions_accepted']);
+
 @Injectable()
 export class GithubWebhookService {
   private githubClient: GithubClient;
@@ -23,6 +25,11 @@ export class GithubWebhookService {
   }
 
   async handleWebhook(headers: Record<string, any>, payload: Record<string, any>): Promise<void> {
+    if (ignoredEventActions.has(payload.action)) {
+      // We do not handle these events.
+      return;
+    }
+
     const context = new WebhookContext({
       github: this.githubClient,
       eventType: `${headers['x-github-event']}.${payload.action}` as EventType,


### PR DESCRIPTION
This event does not contain the base data we need to properly react on in, so it throws currently.
We do not want/need this event, so we can just ignore it and return early.