### PR TITLE
Add handler for blocking labels

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -5,6 +5,7 @@ import { GithubWebhooksModule } from '@dev-thought/nestjs-github-webhooks';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AppConfig } from '../config';
 import { GithubWebhookController } from './github-webhook.controller';
+import { BlockingLabels } from './handlers/blocking_labels';
 import { BranchLabels } from './handlers/branch_labels';
 import { CodeOwnersMention } from './handlers/code_owners_mention';
 import { DependencyBump } from './handlers/dependency_bump';
@@ -29,6 +30,7 @@ import { ValidateCla } from './handlers/validate-cla';
 
 @Module({
   providers: [
+    BlockingLabels,
     BranchLabels,
     CodeOwnersMention,
     DependencyBump,

--- a/services/bots/src/github-webhook/handlers/blocking_labels.ts
+++ b/services/bots/src/github-webhook/handlers/blocking_labels.ts
@@ -1,0 +1,33 @@
+import { PullRequestLabeledEvent, PullRequestUnlabeledEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository, Repository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { BaseWebhookHandler } from './base';
+
+export const LabelsToCheck: {
+  [key in Repository]?: Record<string, { message: string; success?: string }>;
+} = {
+  [HomeAssistantRepository.CORE]: {
+    'awaiting-frontend': { message: 'This PR is awaiting changes to the frontend' },
+  },
+};
+
+export class BlockingLabels extends BaseWebhookHandler {
+  public allowedEventTypes = [EventType.PULL_REQUEST_LABELED, EventType.PULL_REQUEST_UNLABELED];
+  public allowedRepositories = Object.keys(LabelsToCheck) as Repository[];
+
+  async handle(context: WebhookContext<PullRequestLabeledEvent | PullRequestUnlabeledEvent>) {
+    const currentLabels = new Set(context.payload.pull_request.labels.map((label) => label.name));
+
+    for (const [label, description] of Object.entries(LabelsToCheck[context.repository] || {})) {
+      const hasBlockingLabel = currentLabels.has(label);
+      await context.github.repos.createCommitStatus(
+        context.repo({
+          sha: context.payload.pull_request.head.sha,
+          context: `blocking-label-${label}`,
+          state: hasBlockingLabel ? 'failure' : 'success',
+          description: hasBlockingLabel ? description['message'] : description['success'] || 'OK',
+        }),
+      );
+    }
+  }
+}

--- a/tests/services/bots/github-webhook/handlers/blocking_labels.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/blocking_labels.spec.ts
@@ -1,0 +1,59 @@
+import { WebhookContext } from '../../../../../services/bots/src/github-webhook/github-webhook.model';
+import {
+  BlockingLabels,
+  LabelsToCheck,
+} from '../../../../../services/bots/src/github-webhook/handlers/blocking_labels';
+import { loadJsonFixture } from '../../../../utils/fixture';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import {
+  ESPHomeRepository,
+  EventType,
+  HomeAssistantRepository,
+  Repository,
+} from '../../../../../services/bots/src/github-webhook/github-webhook.const';
+
+describe('BlockingLabels', () => {
+  let handler: BlockingLabels;
+  let mockContext: WebhookContext<any>;
+  let createCommitStatusCall: any;
+
+  beforeEach(function () {
+    handler = new BlockingLabels();
+    createCommitStatusCall = {};
+    mockContext = mockWebhookContext({
+      payload: loadJsonFixture('pull_request.opened'),
+      eventType: EventType.PULL_REQUEST_LABELED,
+      // @ts-ignore partial mock
+      github: {
+        repos: {
+          // @ts-ignore partial mock
+          createCommitStatus: jest.fn(),
+        },
+      },
+    });
+  });
+
+  for (const [repository, lables] of Object.entries(LabelsToCheck)) {
+    for (const label of Object.keys(lables)) {
+      for (const result of ['success', 'failure']) {
+        const description =
+          LabelsToCheck[repository][label][result === 'failure' ? 'message' : 'success'] || 'OK';
+        it(`Validate handling ${label} for ${repository} with ${result} result (${description})`, async () => {
+          mockContext.payload = loadJsonFixture('pull_request.opened', {
+            pull_request: { labels: result === 'failure' ? [{ name: label }] : [] },
+          });
+          mockContext.repository = repository as Repository;
+          await handler.handle(mockContext);
+
+          expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith(
+            expect.objectContaining({
+              context: `blocking-label-${label}`,
+              description,
+              state: result,
+            }),
+          );
+        });
+      }
+    }
+  }
+});

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -110,9 +110,44 @@ describe('GithubWebhookModule', () => {
     },
     {
       eventType: EventType.PULL_REQUEST_UNLABELED,
-      handlers: ['DocsMissing', 'PlatinumReview'],
+      handlers: ['BlockingLabels', 'DocsMissing', 'PlatinumReview'],
       payload: {
         repository: { full_name: 'home-assistant/core', owner: { login: 'home-assistant' } },
+      },
+    },
+    {
+      eventType: EventType.PULL_REQUEST_LABELED,
+      handlers: [
+        'BlockingLabels',
+        'CodeOwnersMention',
+        'DocsMissing',
+        'NewIntegrationsHandler',
+        'PlatinumReview',
+        'QualityScaleLabeler',
+        'ValidateCla',
+      ],
+      payload: {
+        repository: { full_name: 'home-assistant/core', owner: { login: 'home-assistant' } },
+      },
+    },
+    {
+      eventType: EventType.PULL_REQUEST_UNLABELED,
+      handlers: [],
+      payload: {
+        repository: {
+          full_name: 'home-assistant/home-assistant.io',
+          owner: { login: 'home-assistant' },
+        },
+      },
+    },
+    {
+      eventType: EventType.PULL_REQUEST_LABELED,
+      handlers: ['CodeOwnersMention', 'ValidateCla'],
+      payload: {
+        repository: {
+          full_name: 'home-assistant/home-assistant.io',
+          owner: { login: 'home-assistant' },
+        },
       },
     },
     {
@@ -180,6 +215,13 @@ describe('GithubWebhookModule', () => {
     },
     {
       eventType: EventType.PULL_REQUEST_UNLABELED,
+      handlers: [],
+      payload: {
+        repository: { full_name: 'esphome/esphome', owner: { login: 'esphome' } },
+      },
+    },
+    {
+      eventType: EventType.PULL_REQUEST_LABELED,
       handlers: [],
       payload: {
         repository: { full_name: 'esphome/esphome', owner: { login: 'esphome' } },


### PR DESCRIPTION
This adds a new handler to check for labels that should be blocking.
As a start, this will check for the "awaiting-frontend" label in the home-assistant/core repository only, but the `LabelsToCheck` object can easily be extended to add more repositories and labels later.