### PR TITLE
Extract all doc links in updateDocsParentStatus

### DIFF
--- a/services/bots/src/github-webhook/handlers/docs_parenting.ts
+++ b/services/bots/src/github-webhook/handlers/docs_parenting.ts
@@ -112,9 +112,9 @@ const updateDocsParentStatus = async (
     return;
   }
 
-  const linksToDocs = extractIssuesOrPullRequestMarkdownLinks(
-    context.payload.pull_request.body,
-  ).filter((link) => `${link.owner}/${link.repo}` === HomeAssistantRepository.HOME_ASSISTANT_IO);
+  const linksToDocs = extractIssuesOrPullRequestMarkdownLinks(context.payload.pull_request.body)
+    .concat(extractPullRequestURLLinks(context.payload.pull_request.body))
+    .filter((link) => `${link.owner}/${link.repo}` === HomeAssistantRepository.HOME_ASSISTANT_IO);
 
   if (linksToDocs.length !== 1) {
     return;


### PR DESCRIPTION
Currently the `updateDocsParentStatus` handler only looks at shortform MD links, like `home-assistant/home-assistant#123`, most people are not using that format.

This PR changes the behavior to also include regular URLs, like `https://github.com/home-assistant/home-assistant.io/pull/123`