### PR TITLE
Add "parent-merged" to docs PR not the invoker

### DIFF
--- a/services/bots/src/github-webhook/handlers/docs_parenting.ts
+++ b/services/bots/src/github-webhook/handlers/docs_parenting.ts
@@ -157,7 +157,15 @@ const updateDocsParentStatus = async (
   }
 
   // Parent state == merged
-  context.scheduleIssueLabel('parent-merged');
+  if (parentState === 'merged') {
+    await context.github.issues.addLabels({
+      owner: docLink.owner,
+      repo: docLink.repo,
+      issue_number: docLink.number,
+      labels: ['parent-merged'],
+    });
+    return;
+  }
 };
 
 const getPRState = (pr: { state: string; merged: boolean }) =>


### PR DESCRIPTION
`context.scheduleIssueLabel('parent-merged');` would schedule the label to be added with the context that triggered this function to be run.
In this case, that would be core/frontend, but we want this to be added to the docs PR.