### PR TITLE
Update WTH labeling strategy to include category ID 61

### DIFF
--- a/services/bots/src/github-webhook/handlers/month_of_wth.ts
+++ b/services/bots/src/github-webhook/handlers/month_of_wth.ts
@@ -4,7 +4,7 @@ import { WebhookContext } from '../github-webhook.model';
 import { extractForumLinks } from '../utils/text_parser';
 import { BaseWebhookHandler } from './base';
 
-const WTH_CATEGORY_ID = 56;
+const WTH_CATEGORY_IDS = [56, 61];
 
 export class MonthOfWTH extends BaseWebhookHandler {
   public allowedEventTypes = [EventType.PULL_REQUEST_OPENED];
@@ -16,7 +16,7 @@ export class MonthOfWTH extends BaseWebhookHandler {
     )) {
       try {
         const linkData = await (await fetch(`${link}.json`)).json();
-        if (linkData.category_id === WTH_CATEGORY_ID) {
+        if (WTH_CATEGORY_IDS.includes(linkData.category_id)) {
           context.scheduleIssueLabel('WTH');
           return;
         }


### PR DESCRIPTION
Update the labeling strategy to include category ID 61 for the month of WTH.

* Modify `services/bots/src/github-webhook/handlers/month_of_wth.ts` to update the `WTH_CATEGORY_ID` constant to include both category IDs 56 and 61.
* Modify the `handle` method to check for both category IDs 56 and 61 when labeling PRs with the WTH label.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/home-assistant/service-hub/pull/282?shareId=811d11b8-8e1b-4400-93d8-9b1dd0d50b2c).