### PR TITLE
Make the attachment filename unique and identifiable

### DIFF
--- a/services/bots/src/discord/listeners/common/line_count_enforcer.ts
+++ b/services/bots/src/discord/listeners/common/line_count_enforcer.ts
@@ -65,7 +65,7 @@ export class ListenerCommonLineCountEnforcer {
         name: `${[message.channel.name, message.author.username, message.id]
           .join('_')
           .toLowerCase()
-          .replace('-', '_')}.${KNOWN_FILETYPES.has(fileType) ? fileType : 'txt'}`,
+          .replace(/-/g, '_')}.${KNOWN_FILETYPES.has(fileType) ? fileType : 'txt'}`,
       });
       await message.channel.send({
         content: `<@${message.author.id}> I converted your message into a file since it's above 15 lines :+1:`,

--- a/services/bots/src/discord/listeners/common/line_count_enforcer.ts
+++ b/services/bots/src/discord/listeners/common/line_count_enforcer.ts
@@ -58,13 +58,14 @@ export class ListenerCommonLineCountEnforcer {
         } else if (!language && contentIsValidYaml(content)) {
           language = 'yaml';
         }
-        fileType = language;
+        fileType = language.toLowerCase();
         messageContent = content;
       }
       const attachment = new AttachmentBuilder(Buffer.from(messageContent, 'utf-8'), {
-        name: `message.${
-          KNOWN_FILETYPES.has(fileType.toLowerCase()) ? fileType.toLowerCase() : 'txt'
-        }`,
+        name: `${[message.channel.name, message.author.username, message.id]
+          .join('_')
+          .toLowerCase()
+          .replace('-', '_')}.${KNOWN_FILETYPES.has(fileType) ? fileType : 'txt'}`,
       });
       await message.channel.send({
         content: `<@${message.author.id}> I converted your message into a file since it's above 15 lines :+1:`,

--- a/tests/services/bots/discord/listeners/line_count_enforce.spec.ts
+++ b/tests/services/bots/discord/listeners/line_count_enforce.spec.ts
@@ -17,7 +17,8 @@ describe('ListenerCommonLineCountEnforcer', () => {
     sendMessage = {};
     mockMessage = {
       content: '',
-      author: { bot: false, id: '1337' },
+      author: { bot: false, id: '1337', username: 'loremIpsum' },
+      id: '1337',
       member: {
         roles: {
           cache: [{}],
@@ -29,6 +30,7 @@ describe('ListenerCommonLineCountEnforcer', () => {
           sendMessage = content;
         },
         type: ChannelType.GuildText,
+        name: 'The-best-channel',
       },
       // @ts-ignore
       delete: (val) => val,
@@ -42,7 +44,7 @@ describe('ListenerCommonLineCountEnforcer', () => {
       sendMessage.content,
       `<@${mockMessage.author.id}> I converted your message into a file since it's above 15 lines :+1:`,
     );
-    assert.deepStrictEqual(sendMessage.files[0].name, 'message.txt');
+    assert.deepStrictEqual(sendMessage.files[0].name, 'the_best_channel_loremipsum_1337.txt');
   });
   it('Content is not large', async () => {
     mockMessage.content = [...Array(MAX_LINE_LENGTH).keys()].map(() => `hi`).join('\n');
@@ -58,7 +60,7 @@ describe('ListenerCommonLineCountEnforcer', () => {
       sendMessage.content,
       `<@${mockMessage.author.id}> I converted your message into a file since it's above 15 lines :+1:`,
     );
-    assert.deepStrictEqual(sendMessage.files[0].name, 'message.yaml');
+    assert.deepStrictEqual(sendMessage.files[0].name, 'the_best_channel_loremipsum_1337.yaml');
   });
 
   it('Content is large and language is unknown but valid YAML', async () => {
@@ -71,7 +73,7 @@ describe('ListenerCommonLineCountEnforcer', () => {
       sendMessage.content,
       `<@${mockMessage.author.id}> I converted your message into a file since it's above 15 lines :+1:`,
     );
-    assert.deepStrictEqual(sendMessage.files[0].name, 'message.yaml');
+    assert.deepStrictEqual(sendMessage.files[0].name, 'the_best_channel_loremipsum_1337.yaml');
   });
 
   it('Content is large and language is unknown but valid JSON', async () => {
@@ -84,7 +86,7 @@ describe('ListenerCommonLineCountEnforcer', () => {
       sendMessage.content,
       `<@${mockMessage.author.id}> I converted your message into a file since it's above 15 lines :+1:`,
     );
-    assert.deepStrictEqual(sendMessage.files[0].name, 'message.json');
+    assert.deepStrictEqual(sendMessage.files[0].name, 'the_best_channel_loremipsum_1337.json');
   });
 
   it('Content is large and language is unknown', async () => {
@@ -95,7 +97,7 @@ describe('ListenerCommonLineCountEnforcer', () => {
       sendMessage.content,
       `<@${mockMessage.author.id}> I converted your message into a file since it's above 15 lines :+1:`,
     );
-    assert.deepStrictEqual(sendMessage.files[0].name, 'message.txt');
+    assert.deepStrictEqual(sendMessage.files[0].name, 'the_best_channel_loremipsum_1337.txt');
   });
 
   it('Ignore bots', async () => {


### PR DESCRIPTION
Currently, all attachments posted by the discord bot are named "message.txt".
This is not great and results in a lot of not easily identifiable files (generally "message (3566782).txt).

This PR changes the name to be constructed based on who posted and also the message ID.

Before:
![2025-01-16_07-26-30](https://github.com/user-attachments/assets/a66931b7-dd6c-4a5e-a02b-642afd6e9da3)

After:
![2025-01-16_07-26-13](https://github.com/user-attachments/assets/e86fd85e-41b9-45e1-823e-fe5fe699ba20)
