### PR TITLE
Add IssueContext handler to provide more context when issues are opened

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN \
 FROM node:20-slim
 WORKDIR /app
 COPY --from=builder /app/.yarn /app/.yarn
+COPY --from=builder /app/data /app/data
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/libs /app/libs
 COPY --from=builder /usr/bin/git /usr/bin/git

--- a/data/github/issue_context.yaml
+++ b/data/github/issue_context.yaml
@@ -1,2 +1,11 @@
 "integration: demo": >-
   This is a demo integration.
+"integration: zha": >-
+  Please make sure your report includes the following things:
+
+  1. Please enable ZHA debug logging, let it run for 10-15 minutes, and make sure to capture whatever problem you're having in the debug log.
+  2. Download diagnostics JSON for the ZHA Integration for the specific devices you're having problems with.
+  3. Any issues whatsoever with Tuya devices or device support requests in general need to be made in the ZHA quirks repo https://github.com/zigpy/zha-device-handlers/issues, not Core's issue tracker.
+  5. Fill out the issue template and include whether or not you're using a VM/Proxmox with USB passthrough, what addons you have installed, and so on.
+
+  ZHA does not have low-level control over your network, the mesh is self-organizing. If you started having network issues in a specific release, the release probably didn't cause the issue. Check your environment for new sources of 2.4GHz interference and make sure you're using an extension cable, not placing the coordinator near SSDs and USB 3.0 ports, etc. Just because things worked in the past with a bad setup doesn't mean they'll keep working in the future.

--- a/data/github/issue_context.yaml
+++ b/data/github/issue_context.yaml
@@ -1,0 +1,2 @@
+"integration: demo": >-
+  This is a demo integration.

--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -15,6 +15,7 @@ import { DocsTargetBranch } from './handlers/docs_target_branch';
 import { Hacktoberfest } from './handlers/hacktoberfest';
 import { SetIntentsLanguage } from './handlers/intents_language';
 import { IssueCommentCommands } from './handlers/issue_comment_commands/handler';
+import { IssueContext } from './handlers/issue_context';
 import { IssueLinks } from './handlers/issue_links';
 import { LabelBot } from './handlers/label_bot/handler';
 import { LabelCleaner } from './handlers/label_cleaner';
@@ -41,6 +42,7 @@ import { ValidateCla } from './handlers/validate-cla';
     GithubWebhookService,
     Hacktoberfest,
     IssueCommentCommands,
+    IssueContext,
     IssueLinks,
     LabelBot,
     LabelCleaner,

--- a/services/bots/src/github-webhook/handlers/issue_context.ts
+++ b/services/bots/src/github-webhook/handlers/issue_context.ts
@@ -1,0 +1,32 @@
+import { IssuesLabeledEvent } from '@octokit/webhooks-types';
+import findUp from 'find-up';
+import { readFileSync } from 'fs';
+import yaml from 'js-yaml';
+import { join } from 'path';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { BaseWebhookHandler } from './base';
+
+const dataDirectory = findUp.sync('data', { cwd: __filename, type: 'directory' });
+const issueContext = yaml.load(
+  readFileSync(join(dataDirectory, 'github', 'issue_context.yaml')).toString(),
+  {
+    json: true,
+  },
+) as Record<string, string>;
+const withIssueContext = Object.keys(issueContext);
+
+export class IssueContext extends BaseWebhookHandler {
+  public allowedEventTypes = [EventType.ISSUES_LABELED];
+  public allowedRepositories = [HomeAssistantRepository.CORE];
+
+  async handle(context: WebhookContext<IssuesLabeledEvent>) {
+    if (!context.payload.label || !withIssueContext.includes(context.payload.label.name)) {
+      return;
+    }
+    context.scheduleIssueComment({
+      handler: 'IssueContext',
+      comment: issueContext[context.payload.label.name],
+    });
+  }
+}

--- a/tests/services/bots/github-webhook/handlers/issue_context.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/issue_context.spec.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import * as assert from 'assert';
+import { WebhookContext } from '../../../../../bots/src/github-webhook/github-webhook.model';
+import { IssueContext } from '../../../../../services/bots/src/github-webhook/handlers/issue_context';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import { loadJsonFixture } from '../../../../utils/fixture';
+
+describe('IssueContext', () => {
+  let handler: IssueContext;
+  let mockContext: WebhookContext<any>;
+  let getLabelResponse: any;
+
+  beforeEach(function () {
+    handler = new IssueContext();
+    getLabelResponse = {};
+    mockContext = mockWebhookContext({
+      eventType: 'issues.labeled',
+      payload: loadJsonFixture('pull_request.opened', {
+        label: { name: 'integration: demo' },
+      }),
+      github: {
+        issues: {
+          async getLabel() {
+            return getLabelResponse;
+          },
+        },
+      },
+    });
+  });
+
+  it('Add comment', async () => {
+    await handler.handle(mockContext);
+
+    assert.deepStrictEqual(mockContext.scheduledComments, [
+      {
+        handler: 'IssueContext',
+        comment: 'This is a demo integration.',
+      },
+    ]);
+  });
+});

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -59,7 +59,7 @@ describe('GithubWebhookModule', () => {
     },
     {
       eventType: EventType.ISSUES_LABELED,
-      handlers: ['CodeOwnersMention', 'IssueLinks'],
+      handlers: ['CodeOwnersMention', 'IssueContext', 'IssueLinks'],
       payload: {
         repository: { full_name: 'home-assistant/core', owner: { login: 'home-assistant' } },
       },


### PR DESCRIPTION
Adds a new IssueContext handler.

The file `data/github/issue_context.yaml` can be populated with key-value pairs (in YAML and markdown).
The key should match a label, as that is what will be used as the lookup value.

So, for instance, if the label `integration: demo` is added to an issue, then the text "This is a demo integration." will be added to the same comment that adds integration links and ping code owner.

To this one:
![image](https://github.com/user-attachments/assets/caa02983-efb8-47db-8e3d-33f89771172d)
