### PR TITLE
Skip docs-missing checks for release PRs

### DIFF
--- a/services/bots/src/github-webhook/handlers/docs_missing.ts
+++ b/services/bots/src/github-webhook/handlers/docs_missing.ts
@@ -25,6 +25,8 @@ export class DocsMissing extends BaseWebhookHandler {
       PullRequestLabeledEvent | PullRequestUnlabeledEvent | PullRequestSynchronizeEvent
     >,
   ) {
+    const isReleasePR = context.payload.pull_request.base.ref === 'master';
+
     const currentLabels = new Set(context.payload.pull_request.labels.map((label) => label.name));
 
     let needsDocumentation = currentLabels.has('docs-missing');
@@ -46,8 +48,12 @@ export class DocsMissing extends BaseWebhookHandler {
       context.repo({
         sha: context.payload.pull_request.head.sha,
         context: 'docs-missing',
-        state: needsDocumentation ? 'failure' : 'success',
-        description: needsDocumentation ? `Please open a documentation PR.` : `Documentation ok.`,
+        state: isReleasePR || !needsDocumentation ? 'success' : 'failure',
+        description: isReleasePR 
+          ? 'Documentation check auto-approved for release PR.' 
+          : needsDocumentation 
+          ? 'Please open a documentation PR.' 
+          : 'Documentation ok.',
       }),
     );
   }

--- a/tests/services/bots/github-webhook/handlers/docs_missing.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/docs_missing.spec.ts
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import * as assert from 'assert';
+import { WebhookContext } from '../../../../../services/bots/src/github-webhook/github-webhook.model';
+import { DocsMissing } from '../../../../../services/bots/src/github-webhook/handlers/docs_missing';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import { loadJsonFixture } from '../../../../utils/fixture';
+
+describe('DocsMissing', () => {
+  let handler: DocsMissing;
+  let mockContext: WebhookContext<any>;
+  let createCommitStatusContents: any;
+
+  beforeEach(function () {
+    handler = new DocsMissing();
+    createCommitStatusContents = {};
+    mockContext = mockWebhookContext({
+      eventType: 'pull_request.labeled',
+      payload: loadJsonFixture('pull_request.opened', {}),
+      github: {
+        repos: {
+          async createCommitStatus(params: any) {
+            createCommitStatusContents = params;
+          },
+        },
+      },
+    });
+  });
+
+  it('PR targeting master branch should auto-approve docs check', async () => {
+    mockContext.github.repos.createCommitStatus = jest.fn();
+    // Override the base ref to target master
+    mockContext.payload.pull_request.base.ref = 'master';
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+      owner: 'Codertocat',
+      repo: 'Hello-World',
+      sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
+      context: 'docs-missing',
+      state: 'success',
+      description: 'Documentation check auto-approved for release PR.',
+    });
+  });
+
+  it('PR targeting dev branch should run docs check - no labels', async () => {
+    mockContext.github.repos.createCommitStatus = jest.fn();
+    // Override the base ref to target dev (non-master branch)
+    mockContext.payload.pull_request.base.ref = 'dev';
+    // Clear any existing labels
+    mockContext.payload.pull_request.labels = [];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+      owner: 'Codertocat',
+      repo: 'Hello-World',
+      sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
+      context: 'docs-missing',
+      state: 'success',
+      description: 'Documentation ok.',
+    });
+  });
+
+  it('PR targeting dev branch with docs-missing label should fail', async () => {
+    mockContext.github.repos.createCommitStatus = jest.fn();
+    // Override the base ref to target dev (non-master branch)
+    mockContext.payload.pull_request.base.ref = 'dev';
+    // Add docs-missing label
+    mockContext.payload.pull_request.labels = [{ name: 'docs-missing' }];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+      owner: 'Codertocat',
+      repo: 'Hello-World',
+      sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
+      context: 'docs-missing',
+      state: 'failure',
+      description: 'Please open a documentation PR.',
+    });
+  });
+
+  it('PR targeting dev branch with new-integration label but no docs link should fail', async () => {
+    mockContext.github.repos.createCommitStatus = jest.fn();
+    // Override the base ref to target dev (non-master branch)
+    mockContext.payload.pull_request.base.ref = 'dev';
+    // Add new-integration label
+    mockContext.payload.pull_request.labels = [{ name: 'new-integration' }];
+    // Clear the body to not have any docs links
+    mockContext.payload.pull_request.body = 'This is a new integration without docs link.';
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+      owner: 'Codertocat',
+      repo: 'Hello-World',
+      sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
+      context: 'docs-missing',
+      state: 'failure',
+      description: 'Please open a documentation PR.',
+    });
+  });
+});


### PR DESCRIPTION
Release PRs are different; we merge the branches and don't have a direct documentation PR for them.

This PR adjust the behavior to prevent a constant check error on those PRs. Added tests.