### PR TITLE
Add set-integration issue comment command

### DIFF
--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
@@ -46,7 +46,7 @@ function parseIntegrationFromInput(input: string): string | undefined {
   return undefined;
 }
 
-export class SetIntegrationCommentCommand implements IssueCommentCommandBase {
+export class SetIntegrationCommentCommand extends IssueCommentCommandBase {
   command = 'set-integration';
   exampleAdditional = 'zha';
   requireAdditional = false;
@@ -58,7 +58,7 @@ export class SetIntegrationCommentCommand implements IssueCommentCommandBase {
   async handle(
     context: WebhookContext<IssueCommentCreatedEvent>,
     command: IssueCommentCommandContext,
-  ) {
+  ): Promise<boolean> {
     // Only allow on issues, not on pull requests
     if (context.payload.issue.pull_request) {
       await context.github.issues.createComment(
@@ -155,5 +155,6 @@ export class SetIntegrationCommentCommand implements IssueCommentCommandBase {
     }
 
     await context.github.issues.addLabels(context.issue({ labels: [label] }));
+    return true;
   }
 }

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
@@ -1,0 +1,135 @@
+import { IssueCommentCreatedEvent } from '@octokit/webhooks-types';
+import { entityComponents } from '../../../github-webhook.const';
+import { WebhookContext } from '../../../github-webhook.model';
+import { fetchIntegrationManifest } from '../../../utils/integration';
+import { extractIntegrationDocumentationLinks } from '../../../utils/text_parser';
+import { invokerIsCodeOwner, IssueCommentCommandContext } from '../const';
+import { IssueCommentCommandBase } from './base';
+
+const USAGE_HINT = [
+  'Use the integration domain name or a documentation link.',
+  'Example: `@home-assistant set-integration zha`',
+  'or: `@home-assistant set-integration https://www.home-assistant.io/integrations/zha`',
+  '',
+  'You can find the domain name in the URL of the integration page on the ' +
+    'Home Assistant website (e.g. `https://www.home-assistant.io/integrations/<domain>`) ' +
+    'or in your local Home Assistant instance under ' +
+    '**Settings → Devices & Services** (e.g. `http://<ip>:8123/config/integrations/integration/<domain>`).',
+].join('\n');
+
+function parseIntegrationFromInput(input: string): string | undefined {
+  const links = extractIntegrationDocumentationLinks(input);
+  if (links.length > 0) {
+    const link = links[0];
+    return link.platform && entityComponents.has(link.integration)
+      ? link.platform
+      : link.integration;
+  }
+  if (/^\w+$/.test(input.trim())) {
+    return input.trim();
+  }
+  return undefined;
+}
+
+export class SetIntegrationCommentCommand implements IssueCommentCommandBase {
+  command = 'set-integration';
+  exampleAdditional = 'zha';
+  requireAdditional = true;
+
+  description(_context: WebhookContext<any>) {
+    return 'Set the integration label on an issue.';
+  }
+
+  async handle(
+    context: WebhookContext<IssueCommentCreatedEvent>,
+    command: IssueCommentCommandContext,
+  ) {
+    // Only allow on issues, not on pull requests
+    if (context.payload.issue.pull_request) {
+      await context.github.issues.createComment(
+        context.issue({ body: 'This command can only be used on issues, not on pull requests.' }),
+      );
+      throw new Error('Not an issue.');
+    }
+
+    const integration = parseIntegrationFromInput(command.additional)?.toLowerCase();
+    if (!integration) {
+      await context.github.issues.createComment(
+        context.issue({
+          body: `Could not determine the integration from the provided input.\n${USAGE_HINT}`,
+        }),
+      );
+      throw new Error('Could not parse integration.');
+    }
+
+    // Check if the integration label exists
+    const label = `integration: ${integration}`;
+
+    // Check if the label is already set
+    if (command.currentLabels.includes(label)) {
+      await context.github.issues.createComment(
+        context.issue({ body: `The integration \`${integration}\` is already set on this issue.` }),
+      );
+      throw new Error('Label already set.');
+    }
+
+    const exist = await context.github.issuesGetLabel(context.issue({ name: label, repo: 'core' }));
+    if (exist?.name !== label) {
+      await context.github.issues.createComment(
+        context.issue({
+          body: `The integration \`${integration}\` was not found.\n${USAGE_HINT}`,
+        }),
+      );
+      throw new Error('Integration not found.');
+    }
+
+    // Check permissions
+    const hasIntegrationLabel = command.currentLabels.some((l) => l.startsWith('integration: '));
+
+    if (hasIntegrationLabel) {
+      // Integration already set: only code owner of the EXISTING integration can change it
+      if (!invokerIsCodeOwner(command)) {
+        await context.github.issues.createComment(
+          context.issue({
+            body: 'An integration is already set on this issue. Only code owners of the currently set integration can change it.',
+          }),
+        );
+        throw new Error('Not authorized to change integration.');
+      }
+    } else {
+      // No integration set: issue author or code owner of the TARGET integration can set it
+      const isIssueAuthor =
+        command.invoker.toLowerCase() === context.payload.issue.user.login.toLowerCase();
+
+      let isTargetCodeOwner = false;
+      if (!isIssueAuthor) {
+        try {
+          const manifest = await fetchIntegrationManifest(integration);
+          isTargetCodeOwner =
+            manifest?.codeowners
+              ?.map((co) => co.substring(1).toLowerCase())
+              ?.includes(command.invoker.toLowerCase()) ?? false;
+        } catch (_) {
+          // If we can't fetch the manifest, we can't verify code ownership
+        }
+      }
+
+      if (!isIssueAuthor && !isTargetCodeOwner) {
+        await context.github.issues.createComment(
+          context.issue({
+            body: 'Only the issue author and code owners can use this command.',
+          }),
+        );
+        throw new Error('Not authorized.');
+      }
+    }
+
+    // Remove old integration labels before adding the new one
+    const oldIntegrationLabels = command.currentLabels.filter((l) => l.startsWith('integration: '));
+    for (const oldLabel of oldIntegrationLabels) {
+      await context.github.issues.removeLabel(context.issue({ name: oldLabel }));
+    }
+
+    await context.github.issues.addLabels(context.issue({ labels: [label] }));
+  }
+}

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
@@ -25,8 +25,23 @@ function parseIntegrationFromInput(input: string): string | undefined {
       ? link.platform
       : link.integration;
   }
-  if (/^\w+$/.test(input.trim())) {
-    return input.trim();
+
+  const trimmed = input.trim();
+
+  // Support dot-separated entity platforms like "sensor.awesome" or "awesome.sensor"
+  const dotParts = trimmed.split('.');
+  if (dotParts.length === 2) {
+    const [first, second] = dotParts;
+    if (entityComponents.has(first) && /^\w+$/.test(second)) {
+      return second;
+    }
+    if (entityComponents.has(second) && /^\w+$/.test(first)) {
+      return first;
+    }
+  }
+
+  if (/^\w+$/.test(trimmed)) {
+    return trimmed;
   }
   return undefined;
 }
@@ -34,7 +49,7 @@ function parseIntegrationFromInput(input: string): string | undefined {
 export class SetIntegrationCommentCommand implements IssueCommentCommandBase {
   command = 'set-integration';
   exampleAdditional = 'zha';
-  requireAdditional = true;
+  requireAdditional = false;
 
   description(_context: WebhookContext<any>) {
     return 'Set the integration label on an issue.';
@@ -50,6 +65,15 @@ export class SetIntegrationCommentCommand implements IssueCommentCommandBase {
         context.issue({ body: 'This command can only be used on issues, not on pull requests.' }),
       );
       throw new Error('Not an issue.');
+    }
+
+    if (!command.additional) {
+      await context.github.issues.createComment(
+        context.issue({
+          body: `Please provide an integration domain or documentation link.\n${USAGE_HINT}`,
+        }),
+      );
+      throw new Error('No integration provided.');
     }
 
     const integration = parseIntegrationFromInput(command.additional)?.toLowerCase();

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/commands/set-integration.ts
@@ -7,14 +7,8 @@ import { invokerIsCodeOwner, IssueCommentCommandContext } from '../const';
 import { IssueCommentCommandBase } from './base';
 
 const USAGE_HINT = [
-  'Use the integration domain name or a documentation link.',
   'Example: `@home-assistant set-integration zha`',
-  'or: `@home-assistant set-integration https://www.home-assistant.io/integrations/zha`',
-  '',
-  'You can find the domain name in the URL of the integration page on the ' +
-    'Home Assistant website (e.g. `https://www.home-assistant.io/integrations/<domain>`) ' +
-    'or in your local Home Assistant instance under ' +
-    '**Settings → Devices & Services** (e.g. `http://<ip>:8123/config/integrations/integration/<domain>`).',
+  'You can also paste the Home Assistant integration documentation URL.',
 ].join('\n');
 
 function parseIntegrationFromInput(input: string): string | undefined {

--- a/services/bots/src/github-webhook/handlers/issue_comment_commands/handler.ts
+++ b/services/bots/src/github-webhook/handlers/issue_comment_commands/handler.ts
@@ -14,6 +14,7 @@ import { UnassignIssueCommentCommand } from './commands/unassign';
 import { UpdateBranchCommentCommand } from './commands/update-branch';
 import { LabelAddCommentCommand } from './commands/label-add';
 import { LabelRemoveCommentCommand } from './commands/label-remove';
+import { SetIntegrationCommentCommand } from './commands/set-integration';
 
 const COMMAND_REGEX: RegExp =
   /^(?<tagged>@home-assistant)\s(?<command>[\w|-]*)(\s(?<additional>.*))?$/;
@@ -28,6 +29,7 @@ export const ISSUE_COMMENT_COMMANDS: IssueCommentCommandBase[] = [
   new UpdateBranchCommentCommand(),
   new LabelAddCommentCommand(),
   new LabelRemoveCommentCommand(),
+  new SetIntegrationCommentCommand(),
 ];
 
 export class IssueCommentCommands extends BaseWebhookHandler {

--- a/services/bots/src/github-webhook/handlers/set_integration.ts
+++ b/services/bots/src/github-webhook/handlers/set_integration.ts
@@ -39,11 +39,7 @@ export class SetIntegration extends BaseWebhookHandler {
           'If you know, it would be really helpful if you could set it by commenting:\n\n' +
           '`@home-assistant set-integration <domain>`\n\n' +
           'For example: `@home-assistant set-integration zha`\n' +
-          'or: `@home-assistant set-integration https://www.home-assistant.io/integrations/zha`\n\n' +
-          'You can find the domain name in the URL of the integration page on the ' +
-          'Home Assistant website (e.g. `https://www.home-assistant.io/integrations/<domain>`) ' +
-          'or in your local Home Assistant instance under ' +
-          '**Settings → Devices & Services** (e.g. `http://<ip>:8123/config/integrations/integration/<domain>`).\n\n' +
+          'You can also paste the Home Assistant integration documentation URL.\n\n' +
           'Setting the integration helps route this issue to the right code owner. ' +
           "Don't worry if you're unsure — someone will set it for you, but it may take a bit longer " +
           'for the issue to reach the right maintainer. :heart:',

--- a/services/bots/src/github-webhook/handlers/set_integration.ts
+++ b/services/bots/src/github-webhook/handlers/set_integration.ts
@@ -13,9 +13,10 @@ export class SetIntegration extends BaseWebhookHandler {
   ];
 
   async handle(context: WebhookContext<IssuesOpenedEvent>) {
-    for (const link of extractIntegrationDocumentationLinks(
-      (context.payload.issue as Issue).body,
-    )) {
+    const links = extractIntegrationDocumentationLinks((context.payload.issue as Issue).body);
+
+    let integrationFound = false;
+    for (const link of links) {
       const integration =
         link.platform && entityComponents.has(link.integration) ? link.platform : link.integration;
       const label = `integration: ${integration}`;
@@ -24,7 +25,30 @@ export class SetIntegration extends BaseWebhookHandler {
       );
       if (exist?.name === label) {
         context.scheduleIssueLabel(label);
+        integrationFound = true;
       }
+    }
+
+    if (!integrationFound && context.repository === HomeAssistantRepository.CORE) {
+      const author = (context.payload.issue as Issue).user.login;
+      context.scheduleIssueComment({
+        handler: 'SetIntegration',
+        comment:
+          `Hey @${author} :wave:, thanks for opening this issue! ` +
+          "We couldn't automatically detect which integration this is about. " +
+          'If you know, it would be really helpful if you could set it by commenting:\n\n' +
+          '`@home-assistant set-integration <domain>`\n\n' +
+          'For example: `@home-assistant set-integration zha`\n' +
+          'or: `@home-assistant set-integration https://www.home-assistant.io/integrations/zha`\n\n' +
+          'You can find the domain name in the URL of the integration page on the ' +
+          'Home Assistant website (e.g. `https://www.home-assistant.io/integrations/<domain>`) ' +
+          'or in your local Home Assistant instance under ' +
+          '**Settings → Devices & Services** (e.g. `http://<ip>:8123/config/integrations/integration/<domain>`).\n\n' +
+          'Setting the integration helps route this issue to the right code owner. ' +
+          "Don't worry if you're unsure — someone will set it for you, but it may take a bit longer " +
+          'for the issue to reach the right maintainer. :heart:',
+        priority: 10,
+      });
     }
   }
 }

--- a/tests/services/bots/github-webhook/handlers/issue_comment_commands.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/issue_comment_commands.spec.ts
@@ -469,4 +469,266 @@ describe('IssueCommentCommands', () => {
       expect(mockContext.github.graphql).not.toHaveBeenCalled();
     });
   });
+
+  describe('command: set-integration', () => {
+    beforeEach(function () {
+      mockContext.payload.comment.body = '@home-assistant set-integration zha';
+      (mockContext.github.issuesGetLabel as unknown as jest.Mock).mockResolvedValue({
+        name: 'integration: zha',
+      });
+    });
+
+    it('by issue author with domain name', async () => {
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels = [];
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: zha'] }),
+      );
+    });
+
+    it('by issue author with uppercase domain name', async () => {
+      mockContext.payload.comment.body = '@home-assistant set-integration ZHA';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels = [];
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: zha'] }),
+      );
+    });
+
+    it('by issue author with documentation link', async () => {
+      mockContext.payload.comment.body =
+        '@home-assistant set-integration https://www.home-assistant.io/integrations/zha';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels = [];
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: zha'] }),
+      );
+    });
+
+    it('by issue author with mixed-case documentation link', async () => {
+      mockContext.payload.comment.body =
+        '@home-assistant set-integration https://www.home-assistant.io/integrations/ZHA';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels = [];
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: zha'] }),
+      );
+    });
+
+    it('by code owner of target integration', async () => {
+      mockContext.payload.comment.user.login = 'test';
+      mockContext.payload.issue.labels = [];
+      mockedFetch.mockImplementation(() =>
+        Promise.resolve({
+          json: () => Promise.resolve({ codeowners: ['@test'] }),
+        } as unknown as Response),
+      );
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: zha'] }),
+      );
+    });
+
+    it('rejected for non-author non-codeowner', async () => {
+      mockContext.payload.comment.user.login = 'other';
+      mockContext.payload.issue.labels = [];
+      mockedFetch.mockImplementation(() =>
+        Promise.resolve({
+          json: () => Promise.resolve({ codeowners: ['@someone_else'] }),
+        } as unknown as Response),
+      );
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: 'Only the issue author and code owners can use this command.',
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('rejected when manifest fetch fails for non-author', async () => {
+      mockContext.payload.comment.user.login = 'other';
+      mockContext.payload.issue.labels = [];
+      mockedFetch.mockImplementation(() => Promise.reject(new Error('Network error')));
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: 'Only the issue author and code owners can use this command.',
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('rejected for unknown integration', async () => {
+      mockContext.payload.comment.body = '@home-assistant set-integration nonexistent';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      (mockContext.github.issuesGetLabel as unknown as jest.Mock).mockResolvedValue(undefined);
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('was not found'),
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('rejected on pull request', async () => {
+      mockContext.payload.comment.user.login = 'Codertocat';
+      //@ts-ignore
+      mockContext.payload.issue.pull_request = { url: 'https://api.github.com/...' };
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('only be used on issues'),
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('rejected for unparseable input', async () => {
+      mockContext.payload.comment.body = '@home-assistant set-integration !!!invalid!!!';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('Could not determine the integration'),
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('without additional parameter', async () => {
+      mockContext.payload.comment.body = '@home-assistant set-integration';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('no-op when label already set', async () => {
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels.push(mockedLabel('integration: zha'));
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('already set'),
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('author cannot change existing integration', async () => {
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels = [mockedLabel('integration: other')];
+      mockedFetch.mockImplementation(() =>
+        Promise.resolve({
+          json: () => Promise.resolve({ codeowners: ['@someone_else'] }),
+        } as unknown as Response),
+      );
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('Only code owners of the currently set integration'),
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+
+    it('code owner of existing integration can change it', async () => {
+      mockContext.payload.comment.user.login = 'test';
+      mockContext.payload.issue.labels = [mockedLabel('integration: awesome')];
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.removeLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'integration: awesome' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: zha'] }),
+      );
+    });
+
+    it('code owner of target integration cannot change existing integration', async () => {
+      mockContext.payload.comment.user.login = 'zha_owner';
+      mockContext.payload.issue.labels = [mockedLabel('integration: other')];
+      mockedFetch.mockImplementation((url: string) =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve(
+              url.includes('/other/')
+                ? { codeowners: ['@other_owner'] }
+                : { codeowners: ['@zha_owner'] },
+            ),
+        } as unknown as Response),
+      );
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('Only code owners of the currently set integration'),
+        }),
+      );
+      expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/services/bots/github-webhook/handlers/issue_comment_commands.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/issue_comment_commands.spec.ts
@@ -535,6 +535,23 @@ describe('IssueCommentCommands', () => {
       );
     });
 
+    it('by issue author with dot-separated entity platform', async () => {
+      mockContext.payload.comment.body = '@home-assistant set-integration sensor.awesome';
+      mockContext.payload.comment.user.login = 'Codertocat';
+      mockContext.payload.issue.labels = [];
+      (mockContext.github.issuesGetLabel as unknown as jest.Mock).mockResolvedValue({
+        name: 'integration: awesome',
+      });
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '+1' }),
+      );
+      expect(mockContext.github.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['integration: awesome'] }),
+      );
+    });
+
     it('by code owner of target integration', async () => {
       mockContext.payload.comment.user.login = 'test';
       mockContext.payload.issue.labels = [];
@@ -648,6 +665,11 @@ describe('IssueCommentCommands', () => {
 
       expect(mockContext.github.reactions.createForIssueComment).toHaveBeenCalledWith(
         expect.objectContaining({ content: '-1' }),
+      );
+      expect(mockContext.github.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('Please provide an integration domain'),
+        }),
       );
       expect(mockContext.github.issues.addLabels).not.toHaveBeenCalled();
     });

--- a/tests/services/bots/github-webhook/handlers/set_integration.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/set_integration.spec.ts
@@ -23,7 +23,7 @@ describe('SetIntegration', () => {
     });
   });
 
-  it('Integration label does exsist', async () => {
+  it('Integration label does exist', async () => {
     mockContext.payload.issue.body = 'Link: https://www.home-assistant.io/integrations/awesome';
     getLabelResponse = { name: 'integration: awesome' };
     await handler.handle(mockContext);
@@ -31,7 +31,7 @@ describe('SetIntegration', () => {
     assert.deepStrictEqual(mockContext.scheduledlabels, ['integration: awesome']);
   });
 
-  it('Integration label does not exsist', async () => {
+  it('Integration label does not exist', async () => {
     mockContext.payload.issue.body = 'Link: https://www.home-assistant.io/integrations/not_valid';
     mockContext.repository = HomeAssistantRepository.CORE;
     getLabelResponse = { status: 404 };

--- a/tests/services/bots/github-webhook/handlers/set_integration.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/set_integration.spec.ts
@@ -2,6 +2,7 @@
 import * as assert from 'assert';
 import { WebhookContext } from '../../../../../bots/src/github-webhook/github-webhook.model';
 import { SetIntegration } from '../../../../../services/bots/src/github-webhook/handlers/set_integration';
+import { HomeAssistantRepository } from '../../../../../services/bots/src/github-webhook/github-webhook.const';
 import { mockWebhookContext } from '../../../../utils/test_context';
 
 describe('SetIntegration', () => {
@@ -32,9 +33,13 @@ describe('SetIntegration', () => {
 
   it('Integration label does not exsist', async () => {
     mockContext.payload.issue.body = 'Link: https://www.home-assistant.io/integrations/not_valid';
+    mockContext.repository = HomeAssistantRepository.CORE;
     getLabelResponse = { status: 404 };
     await handler.handle(mockContext);
     assert.deepStrictEqual(mockContext.scheduledlabels, []);
+    assert.strictEqual(mockContext.scheduledComments.length, 1);
+    assert.strictEqual(mockContext.scheduledComments[0].handler, 'SetIntegration');
+    assert.ok(mockContext.scheduledComments[0].comment.includes('@home-assistant set-integration'));
   });
 
   it('Integration with underscore', async () => {
@@ -68,5 +73,28 @@ describe('SetIntegration', () => {
     await handler.handle(mockContext);
 
     assert.deepStrictEqual(mockContext.scheduledlabels, ['integration: awesome']);
+  });
+
+  it('No integration link in body - hint posted to author', async () => {
+    mockContext.payload.issue.body = 'Something is broken, please help.';
+    mockContext.payload.issue.user = { login: 'someuser' };
+    mockContext.repository = HomeAssistantRepository.CORE;
+    await handler.handle(mockContext);
+
+    assert.deepStrictEqual(mockContext.scheduledlabels, []);
+    assert.strictEqual(mockContext.scheduledComments.length, 1);
+    assert.strictEqual(mockContext.scheduledComments[0].handler, 'SetIntegration');
+    assert.ok(mockContext.scheduledComments[0].comment.includes('@someuser'));
+    assert.ok(mockContext.scheduledComments[0].comment.includes('@home-assistant set-integration'));
+    assert.ok(mockContext.scheduledComments[0].comment.includes('set-integration zha'));
+  });
+
+  it('No hint on home-assistant.io repo', async () => {
+    mockContext.payload.issue.body = 'Something is broken, please help.';
+    mockContext.repository = HomeAssistantRepository.HOME_ASSISTANT_IO;
+    await handler.handle(mockContext);
+
+    assert.deepStrictEqual(mockContext.scheduledlabels, []);
+    assert.strictEqual(mockContext.scheduledComments.length, 0);
   });
 });

--- a/tests/utils/test_context.ts
+++ b/tests/utils/test_context.ts
@@ -23,7 +23,6 @@ export const mockWebhookContext = <T>(params: Partial<WebhookContext<T>>): Webho
           removeLabel: jest.fn(),
           addLabels: jest.fn(),
           removeAssignees: jest.fn(),
-          createComment: jest.fn(),
         },
         issuesGetLabel: jest.fn(),
         teams: {

--- a/tests/utils/test_context.ts
+++ b/tests/utils/test_context.ts
@@ -23,7 +23,9 @@ export const mockWebhookContext = <T>(params: Partial<WebhookContext<T>>): Webho
           removeLabel: jest.fn(),
           addLabels: jest.fn(),
           removeAssignees: jest.fn(),
+          createComment: jest.fn(),
         },
+        issuesGetLabel: jest.fn(),
         teams: {
           listMembersInOrg: jest.fn(),
         },


### PR DESCRIPTION
## Summary

Adds a new `@home-assistant set-integration <domain>` command that allows setting integration labels on issues via comment. This addresses the common manual task of assigning integrations to issues where automatic detection fails.

## What's new

### 1. `set-integration` comment command

Users can set the integration on an issue by commenting:

```
@home-assistant set-integration zha
```

or with a documentation link:

```
@home-assistant set-integration https://www.home-assistant.io/integrations/zha
```

**Input handling:**
- Accepts a plain domain name (`zha`, `bosch_shc`) or a Home Assistant docs URL
- Case-insensitive — `ZHA`, `Zha`, `zha` all work
- Entity component platforms are resolved automatically (e.g. `sensor.awesome` → `awesome`)

**Permission model:**
- **No integration set:** The issue author OR a code owner of the target integration can set it
- **Integration already set:** Only a code owner of the *currently set* integration can change it (old label is removed, new one added)

**Validations & feedback:**
- Only works on issues (not pull requests)
- Rejects unknown integrations (label must exist in the core repo)
- Rejects if the same integration label is already set
- Every rejection posts an explanatory comment with usage hints (domain name examples + where to find it on the HA website and local instance)

### 2. Auto-hint on issue open (Core repo only)

When a new issue is opened on the Core repo and no integration can be automatically detected from documentation links in the body, the bot posts a friendly hint comment to the issue author explaining how to use `@home-assistant set-integration`. This only fires on the Core repo — not on home-assistant.io.