### PR TITLE
Only add Top label if PR has not core or new-integration label

### DIFF
--- a/services/bots/src/github-webhook/handlers/label_bot/handler.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/handler.ts
@@ -58,8 +58,11 @@ export class LabelBot extends BaseWebhookHandler {
     if (componentLabelSet.size <= MAX_INTEGRATION_LABELS) {
       componentLabelSet.forEach(labelSet.add, labelSet);
 
-      for (const label of this.integrationAnalytics.getTopLabels(parsed)) {
-        labelSet.add(label);
+      if (!labelSet.has('core')) {
+        // Only add "Top X" labels if we didn't already mark this as core
+        for (const label of this.integrationAnalytics.getTopLabels(parsed)) {
+          labelSet.add(label);
+        }
       }
     }
 

--- a/services/bots/src/github-webhook/handlers/label_bot/handler.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/handler.ts
@@ -27,6 +27,7 @@ const STRATEGIES = new Set([
   warnOnMergeToMaster,
 ]);
 const MAX_INTEGRATION_LABELS = 5;
+const LABELS_PREVENT_TOP_LABELS = new Set(['core', 'new-integration']);
 
 @Injectable()
 export class LabelBot extends BaseWebhookHandler {
@@ -58,8 +59,11 @@ export class LabelBot extends BaseWebhookHandler {
     if (componentLabelSet.size <= MAX_INTEGRATION_LABELS) {
       componentLabelSet.forEach(labelSet.add, labelSet);
 
-      if (!labelSet.has('core')) {
-        // Only add "Top X" labels if we didn't already mark this as core
+      const shouldAddTopLabels = ![...LABELS_PREVENT_TOP_LABELS].some((label) =>
+        labelSet.has(label),
+      );
+      if (shouldAddTopLabels) {
+        // Only add "Top X" labels if we don't have any labels that should prevent them
         for (const label of this.integrationAnalytics.getTopLabels(parsed)) {
           labelSet.add(label);
         }

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -237,6 +237,7 @@ describe('LabelBot', () => {
     ];
     mockContext.payload.pull_request.base = { ref: 'dev' };
     await handler.handle(mockContext);
+    assert.ok(!mockContext.scheduledlabels.includes('Top 50'));
     assert.ok(mockContext.scheduledlabels.includes('Top 100'));
     assert.ok(mockContext.scheduledlabels.includes('Top 200'));
   });

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -6,8 +6,9 @@ import { IntegrationAnalyticsService } from '../../../../../services/bots/src/gi
 
 const mockAnalyticsData = {
   integrations: Object.fromEntries([
-    // Ranks 0-1: filler integrations
-    ...Array.from({ length: 2 }, (_, i) => [`top_integration_${i}`, 10000 - i]),
+    // Ranks 0-1: top integrations used for tests
+    ['sonos', 10000],
+    ['tplink', 9999],
     // Rank 2: mqtt (inside top 50)
     ['mqtt', 9998],
     // Ranks 3-74: fillers
@@ -53,7 +54,7 @@ describe('LabelBot', () => {
     jest.restoreAllMocks();
   });
 
-  it('adds Top 50, Top 100 and Top 200 labels for top 50 integration', async () => {
+  it('does not add Top labels for top 50 integration when it is core', async () => {
     mockContext._prFilesCache = [
       {
         filename: 'homeassistant/components/mqtt/climate.py',
@@ -65,10 +66,42 @@ describe('LabelBot', () => {
       'core',
       'merging-to-master',
       'integration: mqtt',
-      'Top 50',
-      'Top 100',
-      'Top 200',
     ]);
+  });
+
+  it('adds Top 50, Top 100 and Top 200 labels for non-core top 50 integration', async () => {
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/sonos/sensor.py',
+      },
+    ];
+    mockContext.payload.pull_request.base = { ref: 'dev' };
+    await handler.handle(mockContext);
+
+    assert.ok(!mockContext.scheduledlabels.includes('core'));
+    assert.ok(mockContext.scheduledlabels.includes('integration: sonos'));
+    assert.ok(mockContext.scheduledlabels.includes('Top 50'));
+    assert.ok(mockContext.scheduledlabels.includes('Top 100'));
+    assert.ok(mockContext.scheduledlabels.includes('Top 200'));
+  });
+
+  it('does not add Top labels when PR is marked core', async () => {
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/helpers/config_validation.py',
+      },
+      {
+        filename: 'homeassistant/components/mqtt/climate.py',
+      },
+    ];
+    mockContext.payload.pull_request.base = { ref: 'dev' };
+    await handler.handle(mockContext);
+
+    assert.ok(mockContext.scheduledlabels.includes('core'));
+    assert.ok(mockContext.scheduledlabels.includes('integration: mqtt'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 50'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 100'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 200'));
   });
 
   it('adds Top 100 and Top 200 labels for top 100 integration', async () => {
@@ -199,12 +232,11 @@ describe('LabelBot', () => {
         filename: 'homeassistant/components/wled/light.py',
       },
       {
-        filename: 'homeassistant/components/mqtt/climate.py',
+        filename: 'homeassistant/components/tasmota/sensor.py',
       },
     ];
     mockContext.payload.pull_request.base = { ref: 'dev' };
     await handler.handle(mockContext);
-    assert.ok(mockContext.scheduledlabels.includes('Top 50'));
     assert.ok(mockContext.scheduledlabels.includes('Top 100'));
     assert.ok(mockContext.scheduledlabels.includes('Top 200'));
   });

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -241,4 +241,29 @@ describe('LabelBot', () => {
     assert.ok(mockContext.scheduledlabels.includes('Top 100'));
     assert.ok(mockContext.scheduledlabels.includes('Top 200'));
   });
+
+  it('does not add Top labels when adding new integration alongside changes to a top 50 integration', async () => {
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/newintegration/__init__.py',
+        status: 'added',
+      },
+      {
+        filename: 'homeassistant/components/newintegration/sensor.py',
+        status: 'added',
+      },
+      {
+        filename: 'homeassistant/components/sonos/media_player.py',
+      },
+    ];
+    mockContext.payload.pull_request.base = { ref: 'dev' };
+    await handler.handle(mockContext);
+
+    assert.ok(mockContext.scheduledlabels.includes('new-integration'));
+    assert.ok(mockContext.scheduledlabels.includes('integration: newintegration'));
+    assert.ok(mockContext.scheduledlabels.includes('integration: sonos'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 50'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 100'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 200'));
+  });
 });


### PR DESCRIPTION
## Summary

Skip adding "Top 50/100/200" popularity labels when a PR is marked as `core` or `new-integration`.

These labels are based on integration usage rankings, but they're misleading when the PR is fundamentally a core change (where the integration file touch is incidental) or introduces a brand new integration (which has no meaningful popularity ranking yet).