### PR TITLE
Enable LabelBot for supervisor with strategies that make sense there

### DIFF
--- a/services/bots/src/github-webhook/handlers/label_bot/handler.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/handler.ts
@@ -27,7 +27,7 @@ const CORE_STRATEGIES = new Set([
   warnOnMergeToMaster,
 ]);
 
-const SUPERVISOR_STRATEGIES = new Set([hasTests, smallPR, typeOfChange]);
+const SUPERVISOR_STRATEGIES = new Set([typeOfChange]);
 const MAX_INTEGRATION_LABELS = 5;
 const LABELS_PREVENT_TOP_LABELS = new Set(['core', 'new-integration']);
 

--- a/services/bots/src/github-webhook/handlers/label_bot/handler.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/handler.ts
@@ -16,7 +16,7 @@ import typeOfChange from './strategies/typeOfChange';
 import warnOnMergeToMaster from './strategies/warnOnMergeToMaster';
 import { Injectable } from '@nestjs/common';
 
-const STRATEGIES = new Set([
+const CORE_STRATEGIES = new Set([
   configFlow,
   hasTests,
   markCore,
@@ -26,13 +26,15 @@ const STRATEGIES = new Set([
   typeOfChange,
   warnOnMergeToMaster,
 ]);
+
+const SUPERVISOR_STRATEGIES = new Set([hasTests, smallPR, typeOfChange]);
 const MAX_INTEGRATION_LABELS = 5;
 const LABELS_PREVENT_TOP_LABELS = new Set(['core', 'new-integration']);
 
 @Injectable()
 export class LabelBot extends BaseWebhookHandler {
   public allowBots = false;
-  public allowedRepositories = [HomeAssistantRepository.CORE];
+  public allowedRepositories = [HomeAssistantRepository.CORE, HomeAssistantRepository.SUPERVISOR];
   public allowedEventTypes = [EventType.PULL_REQUEST_OPENED];
 
   constructor(private integrationAnalytics: IntegrationAnalyticsService) {
@@ -44,28 +46,35 @@ export class LabelBot extends BaseWebhookHandler {
     const parsed = files.map((file) => new ParsedPath(file));
     const labelSet: Set<string> = new Set();
 
-    STRATEGIES.forEach((strategy) => {
+    const repo = context.payload.repository?.full_name;
+    const strategies =
+      repo === HomeAssistantRepository.SUPERVISOR ? SUPERVISOR_STRATEGIES : CORE_STRATEGIES;
+
+    strategies.forEach((strategy) => {
       for (const label of strategy(context, parsed)) {
         labelSet.add(label);
       }
     });
 
-    // componentAndPlatform can create many labels, process them separately
-    const componentLabelSet = new Set<string>();
-    for (const label of componentAndPlatform(context, parsed)) {
-      componentLabelSet.add(label);
-    }
+    // Supervisor: skip all integration/component labeling steps.
+    if (repo !== HomeAssistantRepository.SUPERVISOR) {
+      // componentAndPlatform can create many labels, process them separately
+      const componentLabelSet = new Set<string>();
+      for (const label of componentAndPlatform(context, parsed)) {
+        componentLabelSet.add(label);
+      }
 
-    if (componentLabelSet.size <= MAX_INTEGRATION_LABELS) {
-      componentLabelSet.forEach(labelSet.add, labelSet);
+      if (componentLabelSet.size <= MAX_INTEGRATION_LABELS) {
+        componentLabelSet.forEach(labelSet.add, labelSet);
 
-      const shouldAddTopLabels = ![...LABELS_PREVENT_TOP_LABELS].some((label) =>
-        labelSet.has(label),
-      );
-      if (shouldAddTopLabels) {
-        // Only add "Top X" labels if we don't have any labels that should prevent them
-        for (const label of this.integrationAnalytics.getTopLabels(parsed)) {
-          labelSet.add(label);
+        const shouldAddTopLabels = ![...LABELS_PREVENT_TOP_LABELS].some((label) =>
+          labelSet.has(label),
+        );
+        if (shouldAddTopLabels) {
+          // Only add "Top X" labels if we don't have any labels that should prevent them
+          for (const label of this.integrationAnalytics.getTopLabels(parsed)) {
+            labelSet.add(label);
+          }
         }
       }
     }

--- a/services/bots/src/github-webhook/handlers/label_bot/strategies/typeOfChange.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/strategies/typeOfChange.ts
@@ -1,9 +1,10 @@
 import { PullRequest, PullRequestOpenedEvent } from '@octokit/webhooks-types';
+import { HomeAssistantRepository } from '../../../github-webhook.const';
 import { WebhookContext } from '../../../github-webhook.model';
 import { ParsedPath } from '../../../utils/parse_path';
 import { extractTasks } from '../../../utils/text_parser';
 
-const BODYMATCHES = [
+const CORE_BODYMATCHES = [
   {
     description: 'Bugfix (non-breaking change which fixes an issue)',
     labels: ['bugfix'],
@@ -34,6 +35,31 @@ const BODYMATCHES = [
   },
 ];
 
+// Matches Supervisor PR template checkboxes:
+// https://github.com/home-assistant/supervisor/blob/667bd627423f4edf6cd199c22d3ef778a6324e37/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L24-L28
+const SUPERVISOR_BODYMATCHES = [
+  {
+    description: 'Dependency upgrade',
+    labels: ['dependency'],
+  },
+  {
+    description: 'Bugfix (non-breaking change which fixes an issue)',
+    labels: ['bugfix'],
+  },
+  {
+    description: 'New feature (which adds functionality to the supervisor)',
+    labels: ['new-feature'],
+  },
+  {
+    description: 'Breaking change (fix/feature causing existing functionality to break)',
+    labels: ['breaking-change'],
+  },
+  {
+    description: 'Code quality improvements to existing code or addition of tests',
+    labels: ['refactor'],
+  },
+];
+
 export default (context: WebhookContext<PullRequestOpenedEvent>, parsed: ParsedPath[]) => {
   const completedTasks = extractTasks((context.payload.pull_request as PullRequest).body || '')
     .filter((task) => {
@@ -41,8 +67,12 @@ export default (context: WebhookContext<PullRequestOpenedEvent>, parsed: ParsedP
     })
     .map((task) => task.description);
 
+  const repo = context.payload.repository?.full_name;
+  const bodyMatches =
+    repo === HomeAssistantRepository.SUPERVISOR ? SUPERVISOR_BODYMATCHES : CORE_BODYMATCHES;
+
   let labels: string[] = [];
-  BODYMATCHES.forEach((match) => {
+  bodyMatches.forEach((match) => {
     if (completedTasks.includes(match.description)) {
       match.labels.forEach((label) => {
         labels.push(label);

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -266,4 +266,45 @@ describe('LabelBot', () => {
     assert.ok(!mockContext.scheduledlabels.includes('Top 100'));
     assert.ok(!mockContext.scheduledlabels.includes('Top 200'));
   });
+
+  it('applies Supervisor-only strategy set and skips integration/component labeling', async () => {
+    mockContext.payload.repository = { full_name: 'home-assistant/supervisor' };
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/mqtt/climate.py',
+        additions: 1,
+      },
+      {
+        filename: 'tests/components/mqtt/test_climate.py',
+        additions: 1,
+      },
+    ];
+    mockContext.payload.pull_request = {
+      body:
+        '\n- [x] Bugfix (non-breaking change which fixes an issue)' +
+        '\n- [x] Code quality improvements to existing code or addition of tests' +
+        '\n- [ ] Dependency upgrade' +
+        '\n- [ ] New feature (which adds functionality to the supervisor)' +
+        '\n- [ ] Breaking change (fix/feature causing existing functionality to break)',
+      base: { ref: 'main' },
+    };
+
+    await handler.handle(mockContext);
+
+    // Should include Supervisor type-of-change labels
+    assert.ok(mockContext.scheduledlabels.includes('bugfix'));
+    assert.ok(mockContext.scheduledlabels.includes('refactor'));
+
+    // Should include test/sizing labels (from Supervisor strategy set)
+    assert.ok(mockContext.scheduledlabels.includes('has-tests'));
+    assert.ok(mockContext.scheduledlabels.includes('small-pr'));
+
+    // Must NOT include Core-only labeling behaviors
+    assert.ok(!mockContext.scheduledlabels.includes('core'));
+    assert.ok(!mockContext.scheduledlabels.some((l) => l.startsWith('integration: ')));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 50'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 100'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 200'));
+    assert.ok(!mockContext.scheduledlabels.includes('merging-to-master'));
+  });
 });

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -295,11 +295,9 @@ describe('LabelBot', () => {
     assert.ok(mockContext.scheduledlabels.includes('bugfix'));
     assert.ok(mockContext.scheduledlabels.includes('refactor'));
 
-    // Should include test/sizing labels (from Supervisor strategy set)
-    assert.ok(mockContext.scheduledlabels.includes('has-tests'));
-    assert.ok(mockContext.scheduledlabels.includes('small-pr'));
-
     // Must NOT include Core-only labeling behaviors
+    assert.ok(!mockContext.scheduledlabels.includes('has-tests'));
+    assert.ok(!mockContext.scheduledlabels.includes('small-pr'));
     assert.ok(!mockContext.scheduledlabels.includes('core'));
     assert.ok(!mockContext.scheduledlabels.some((l) => l.startsWith('integration: ')));
     assert.ok(!mockContext.scheduledlabels.includes('Top 50'));


### PR DESCRIPTION
Supervisor also needs labels set from the checkboxes in its PR template. Adjust the `typeOfChange` strategy to be able to handle Supervisor's template and set our labels.

All the strategies related to integrations and components remain core only.