### PR TITLE
Update small-pr label on PR synchronize events

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -30,6 +30,7 @@ import { RequiredLabels } from './handlers/required_labels';
 import { ReviewDrafter } from './handlers/review_drafter';
 import { SetDocumentationSection } from './handlers/set_documentation_section';
 import { SetIntegration } from './handlers/set_integration';
+import { SmallPRLabelUpdater } from './handlers/small_pr_label_updater';
 import { ValidateCla } from './handlers/validate-cla';
 
 @Module({
@@ -59,6 +60,7 @@ import { ValidateCla } from './handlers/validate-cla';
     SetDocumentationSection,
     SetIntegration,
     SetIntentsLanguage,
+    SmallPRLabelUpdater,
     ValidateCla,
   ],
   imports: [

--- a/services/bots/src/github-webhook/handlers/label_bot/strategies/smallPR.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/strategies/smallPR.ts
@@ -2,12 +2,13 @@ import { PullRequestOpenedEvent } from '@octokit/webhooks-types';
 import { WebhookContext } from '../../../github-webhook.model';
 import { ParsedPath } from '../../../utils/parse_path';
 
-const SMALL_PR_THRESHOLD = 30;
+export const SMALL_PR_THRESHOLD = 30;
 
-export default (context: WebhookContext<PullRequestOpenedEvent>, parsed: ParsedPath[]) =>
+export const isSmallPR = (parsed: ParsedPath[]): boolean =>
   parsed.reduce(
     (tot, file) => (file.type === 'test' || file.type === null ? tot : tot + file.additions),
     0,
-  ) < SMALL_PR_THRESHOLD
-    ? ['small-pr']
-    : [];
+  ) < SMALL_PR_THRESHOLD;
+
+export default (context: WebhookContext<PullRequestOpenedEvent>, parsed: ParsedPath[]) =>
+  isSmallPR(parsed) ? ['small-pr'] : [];

--- a/services/bots/src/github-webhook/handlers/small_pr_label_updater.ts
+++ b/services/bots/src/github-webhook/handlers/small_pr_label_updater.ts
@@ -1,0 +1,32 @@
+import { PullRequestSynchronizeEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { ParsedPath } from '../utils/parse_path';
+import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
+import { BaseWebhookHandler } from './base';
+import { isSmallPR } from './label_bot/strategies/smallPR';
+
+const SMALL_PR_LABEL = 'small-pr';
+
+export class SmallPRLabelUpdater extends BaseWebhookHandler {
+  public allowBots = false;
+  public allowedRepositories = [HomeAssistantRepository.CORE];
+  public allowedEventTypes = [EventType.PULL_REQUEST_SYNCHRONIZE];
+
+  async handle(context: WebhookContext<PullRequestSynchronizeEvent>) {
+    const currentLabels = new Set(
+      context.payload.pull_request.labels.map((label) => label.name),
+    );
+    const hasLabel = currentLabels.has(SMALL_PR_LABEL);
+
+    const files = await fetchPullRequestFilesFromContext(context);
+    const parsed = files.map((file) => new ParsedPath(file));
+    const shouldHaveLabel = isSmallPR(parsed);
+
+    if (shouldHaveLabel && !hasLabel) {
+      context.scheduleIssueLabel(SMALL_PR_LABEL);
+    } else if (!shouldHaveLabel && hasLabel) {
+      await context.github.issues.removeLabel(context.issue({ name: SMALL_PR_LABEL }));
+    }
+  }
+}

--- a/tests/services/bots/github-webhook/handlers/small_pr_label_updater.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/small_pr_label_updater.spec.ts
@@ -1,0 +1,94 @@
+// @ts-nocheck
+import * as assert from 'assert';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import { SmallPRLabelUpdater } from '../../../../../services/bots/src/github-webhook/handlers/small_pr_label_updater';
+import { loadJsonFixture } from '../../../../utils/fixture';
+
+describe('SmallPRLabelUpdater', () => {
+  let handler: SmallPRLabelUpdater;
+  let mockContext;
+
+  beforeEach(() => {
+    handler = new SmallPRLabelUpdater();
+    mockContext = mockWebhookContext({
+      eventType: 'pull_request.synchronize',
+      payload: {
+        ...loadJsonFixture('pull_request.opened'),
+        action: 'synchronize',
+      },
+      github: {
+        issues: {
+          removeLabel: jest.fn(),
+        },
+      },
+    });
+  });
+
+  it('adds small-pr label when PR drops below threshold', async () => {
+    mockContext.payload.pull_request.labels = [];
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/hue/light.py',
+        additions: 10,
+      },
+    ];
+    await handler.handle(mockContext);
+    assert.deepStrictEqual(mockContext.scheduledlabels, ['small-pr']);
+    assert.strictEqual(mockContext.github.issues.removeLabel.mock.calls.length, 0);
+  });
+
+  it('removes small-pr label when PR rises above threshold', async () => {
+    mockContext.payload.pull_request.labels = [{ name: 'small-pr' }];
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/hue/light.py',
+        additions: 50,
+      },
+    ];
+    await handler.handle(mockContext);
+    assert.deepStrictEqual(mockContext.scheduledlabels, []);
+    assert.strictEqual(mockContext.github.issues.removeLabel.mock.calls.length, 1);
+  });
+
+  it('does nothing when PR is small and already has label', async () => {
+    mockContext.payload.pull_request.labels = [{ name: 'small-pr' }];
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/hue/light.py',
+        additions: 10,
+      },
+    ];
+    await handler.handle(mockContext);
+    assert.deepStrictEqual(mockContext.scheduledlabels, []);
+    assert.strictEqual(mockContext.github.issues.removeLabel.mock.calls.length, 0);
+  });
+
+  it('does nothing when PR is large and has no label', async () => {
+    mockContext.payload.pull_request.labels = [];
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/hue/light.py',
+        additions: 50,
+      },
+    ];
+    await handler.handle(mockContext);
+    assert.deepStrictEqual(mockContext.scheduledlabels, []);
+    assert.strictEqual(mockContext.github.issues.removeLabel.mock.calls.length, 0);
+  });
+
+  it('excludes test files from addition count', async () => {
+    mockContext.payload.pull_request.labels = [];
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/hue/light.py',
+        additions: 10,
+      },
+      {
+        filename: 'tests/components/hue/test_light.py',
+        additions: 200,
+      },
+    ];
+    await handler.handle(mockContext);
+    assert.deepStrictEqual(mockContext.scheduledlabels, ['small-pr']);
+  });
+});

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -109,6 +109,7 @@ describe('GithubWebhookModule', () => {
         'MergeConflictChecker',
         'PlatinumReview',
         'RequiredLabels',
+        'SmallPRLabelUpdater',
         'ValidateCla',
       ],
       payload: {


### PR DESCRIPTION
## Summary
- The `small-pr` label was only applied when a PR was first opened but never updated when subsequent commits changed the PR size
- Adds a new `SmallPRLabelUpdater` handler that listens to `pull_request.synchronize` events and re-evaluates the `small-pr` label
- Extracts shared `isSmallPR()` helper from the existing `smallPR` strategy to avoid duplicating threshold logic
- Adds/removes the label as needed: if the PR drops below 30 non-test additions it gets labeled, if it rises above it gets unlabeled

Closes #183

## Test plan
- [x] New unit tests for all 4 scenarios (add label, remove label, no-op with label, no-op without label)
- [x] Test that test files are excluded from the addition count
- [x] Existing `LabelBot` tests still pass (strategy refactor is backward-compatible)
- [x] Handler registration verified in `verify_enabled_handlers.spec.ts`