### PR TITLE
Auto-manage community-approved label on core PRs

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -9,6 +9,7 @@ import { GithubWebhookController } from './github-webhook.controller';
 import { BlockingLabels } from './handlers/blocking_labels';
 import { BranchLabels } from './handlers/branch_labels';
 import { CodeOwnersMention } from './handlers/code_owners_mention';
+import { CommunityApproved } from './handlers/community_approved';
 import { DependencyBump } from './handlers/dependency_bump';
 import { DocsMissing } from './handlers/docs_missing';
 import { DocsParenting } from './handlers/docs_parenting';
@@ -37,6 +38,7 @@ import { ValidateCla } from './handlers/validate-cla';
     BlockingLabels,
     BranchLabels,
     CodeOwnersMention,
+    CommunityApproved,
     DependencyBump,
     DocsMissing,
     DocsParenting,

--- a/services/bots/src/github-webhook/handlers/community_approved.ts
+++ b/services/bots/src/github-webhook/handlers/community_approved.ts
@@ -1,0 +1,60 @@
+import { PullRequestReviewSubmittedEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { BaseWebhookHandler } from './base';
+
+const COMMUNITY_APPROVED_LABEL = 'community-approved';
+
+export class CommunityApproved extends BaseWebhookHandler {
+  public allowedEventTypes = [EventType.PULL_REQUEST_REVIEW_SUBMITTED];
+  public allowedRepositories = [HomeAssistantRepository.CORE];
+
+  async handle(context: WebhookContext<PullRequestReviewSubmittedEvent>) {
+    const submittedState = context.payload.review.state;
+    if (submittedState !== 'approved' && submittedState !== 'changes_requested') {
+      return;
+    }
+
+    const reviews = await context.github.paginate(
+      context.github.pulls.listReviews,
+      context.pullRequest({ per_page: 100 }),
+    );
+
+    // listReviews returns reviews in chronological order; keep the latest
+    // approval-bearing state per human reviewer so a later changes_requested
+    // overrides an earlier approval (and vice versa).
+    const latestStateByUser = new Map<string, string>();
+    for (const review of reviews) {
+      if (!review.user || review.user.type.toLowerCase() === 'bot') {
+        continue;
+      }
+      if (
+        review.state !== 'APPROVED' &&
+        review.state !== 'CHANGES_REQUESTED' &&
+        review.state !== 'DISMISSED'
+      ) {
+        continue;
+      }
+      latestStateByUser.set(review.user.login, review.state);
+    }
+
+    const approverCount = [...latestStateByUser.values()].filter(
+      (state) => state === 'APPROVED',
+    ).length;
+    const hasLabel = context.payload.pull_request.labels.some(
+      (label) => label.name === COMMUNITY_APPROVED_LABEL,
+    );
+
+    if (approverCount >= 2 && !hasLabel) {
+      context.scheduleIssueLabel(COMMUNITY_APPROVED_LABEL);
+    } else if (approverCount < 2 && hasLabel) {
+      try {
+        await context.github.issues.removeLabel(
+          context.issue({ name: COMMUNITY_APPROVED_LABEL }),
+        );
+      } catch {
+        // Label may already be gone
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed Change
- New webhook handler `CommunityApproved` that maintains a `community-approved` label on `home-assistant/core` pull requests.
- The label is added when two or more distinct human reviewers currently have an `APPROVED` state as their latest review, and removed automatically once that count drops below two (e.g. a previously-approving reviewer later submits `changes_requested`).
- Reviews are fetched via `octokit.paginate` and deduplicated per user so the latest approval-bearing state wins — earlier approvals that were later overridden by `CHANGES_REQUESTED` no longer count.

## Behavior
Triggers on `pull_request_review.submitted` events with state `approved` or `changes_requested`. For each event:

1. Fetch all reviews on the PR.
2. For each human reviewer, keep only their most recent `APPROVED` / `CHANGES_REQUESTED` / `DISMISSED` review.
3. Count users whose latest state is `APPROVED`.
4. If ≥ 2 and the label is missing → add it (via `context.scheduleIssueLabel`).
5. If < 2 and the label is present → remove it via `issues.removeLabel`.

Bot reviews are ignored.
