### PR TITLE
Rank Top N labels by integration_type to match the analytics page

### DIFF
--- a/services/bots/src/github-webhook/handlers/label_bot/integration-analytics.service.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/integration-analytics.service.ts
@@ -3,6 +3,11 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { ParsedPath } from '../../utils/parse_path';
 
 const ANALYTICS_URL = 'https://analytics.home-assistant.io/current_data.json';
+const INTEGRATION_DETAILS_URL = 'https://www.home-assistant.io/integrations.json';
+// Only these integration_type values are ranked, mirroring the public analytics
+// integrations page (see sortIntegrations in analytics.home-assistant.io
+// site/.eleventy.js). system/entity/hardware/virtual/brand types are excluded.
+const RANKED_INTEGRATION_TYPES = new Set(['integration', 'hub', 'device', 'helper', 'service']);
 const TOP_COUNTS = [50, 100, 200];
 const FETCH_TIMEOUT_MS = 10000;
 
@@ -17,42 +22,60 @@ export class IntegrationAnalyticsService implements OnModuleInit {
 
   @Cron(CronExpression.EVERY_12_HOURS)
   async updateAnalytics() {
+    const [analytics, details] = await Promise.all([
+      this.fetchJson<{ integrations: Record<string, number> }>(ANALYTICS_URL),
+      this.fetchJson<Record<string, { integration_type?: string }>>(INTEGRATION_DETAILS_URL),
+    ]);
+
+    // Keep the previous ranking if either source is unavailable, rather than
+    // ranking on incomplete data.
+    if (!analytics || !details) {
+      return;
+    }
+
+    const integrations = analytics.integrations;
+    if (!integrations || typeof integrations !== 'object') {
+      this.logger.error('Unexpected analytics response: missing integrations data');
+      return;
+    }
+
+    const maxCount = Math.max(...TOP_COUNTS);
+
+    // Mirror the public analytics integrations page: rank the documented
+    // integrations of a ranked type by install count, so the Top N labels match
+    // where an integration appears there. Ranking the raw analytics map instead
+    // counts system/entity/hardware/... domains and pushes real integrations down.
+    this.rankedIntegrations = Object.keys(details)
+      .filter((domain) => RANKED_INTEGRATION_TYPES.has(details[domain]?.integration_type ?? ''))
+      .map((domain) => ({ domain, installations: integrations[domain] || 0 }))
+      .sort((a, b) => b.installations - a.installations)
+      .slice(0, maxCount)
+      .map((entry) => entry.domain);
+
+    this.logger.log(`Updated integration analytics (${this.rankedIntegrations.length} entries)`);
+  }
+
+  private async fetchJson<T>(url: string): Promise<T | null> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
     try {
-      const response = await fetch(ANALYTICS_URL, { signal: controller.signal });
+      const response = await fetch(url, { signal: controller.signal });
       if (!response.ok) {
-        this.logger.error(
-          `Failed to fetch integration analytics: ${response.status} ${response.statusText}`,
-        );
-        return;
+        this.logger.error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+        return null;
       }
-      const data = await response.json();
-      const integrations: Record<string, number> = data.integrations;
-      if (!integrations || typeof integrations !== 'object') {
-        this.logger.error('Unexpected analytics response: missing integrations data');
-        return;
-      }
-      const maxCount = Math.max(...TOP_COUNTS);
-
-      this.rankedIntegrations = Object.entries(integrations)
-        .sort(([, a], [, b]) => b - a)
-        .slice(0, maxCount)
-        .map(([name]) => name);
-
-      this.logger.log(`Updated integration analytics (${this.rankedIntegrations.length} entries)`);
+      return (await response.json()) as T;
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
-        this.logger.error(
-          `Failed to fetch integration analytics: request timed out after ${FETCH_TIMEOUT_MS}ms`,
-        );
+        this.logger.error(`Failed to fetch ${url}: request timed out after ${FETCH_TIMEOUT_MS}ms`);
       } else {
         this.logger.error(
-          'Failed to fetch integration analytics',
+          `Failed to fetch ${url}`,
           error instanceof Error ? error.stack : String(error),
         );
       }
+      return null;
     } finally {
       clearTimeout(timeoutId);
     }

--- a/services/bots/src/github-webhook/handlers/label_bot/integration-analytics.service.ts
+++ b/services/bots/src/github-webhook/handlers/label_bot/integration-analytics.service.ts
@@ -45,13 +45,21 @@ export class IntegrationAnalyticsService implements OnModuleInit {
     // integrations of a ranked type by install count, so the Top N labels match
     // where an integration appears there. Ranking the raw analytics map instead
     // counts system/entity/hardware/... domains and pushes real integrations down.
-    this.rankedIntegrations = Object.keys(details)
+    const ranked = Object.keys(details)
       .filter((domain) => RANKED_INTEGRATION_TYPES.has(details[domain]?.integration_type ?? ''))
       .map((domain) => ({ domain, installations: integrations[domain] || 0 }))
       .sort((a, b) => b.installations - a.installations)
       .slice(0, maxCount)
       .map((entry) => entry.domain);
 
+    // Don't overwrite a good ranking with an empty result from an unexpected
+    // (but successfully fetched) response shape.
+    if (!ranked.length) {
+      this.logger.error('Computed an empty integration ranking; keeping the previous one');
+      return;
+    }
+
+    this.rankedIntegrations = ranked;
     this.logger.log(`Updated integration analytics (${this.rankedIntegrations.length} entries)`);
   }
 

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -337,4 +337,26 @@ describe('LabelBot', () => {
     assert.ok(!mockContext.scheduledlabels.includes('Top 200'));
     assert.ok(!mockContext.scheduledlabels.includes('merging-to-master'));
   });
+
+  it('keeps the previous ranking when a later update yields an empty result', async () => {
+    const analyticsService = new IntegrationAnalyticsService();
+    await analyticsService.onModuleInit();
+
+    // A successfully fetched but empty integration_details response must not wipe
+    // the previously computed ranking.
+    (global.fetch as jest.Mock).mockImplementation((url) =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(String(url).includes('integrations.json') ? {} : mockAnalyticsData),
+      } as any),
+    );
+    await analyticsService.updateAnalytics();
+
+    assert.deepStrictEqual(analyticsService.getTopLabels([{ component: 'sonos' } as any]), [
+      'Top 50',
+      'Top 100',
+      'Top 200',
+    ]);
+  });
 });

--- a/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/label_bot.spec.ts
@@ -6,6 +6,9 @@ import { IntegrationAnalyticsService } from '../../../../../services/bots/src/gi
 
 const mockAnalyticsData = {
   integrations: Object.fromEntries([
+    // Highest install count, but a non-ranked integration_type (see
+    // mockIntegrationDetails) — must be excluded from the ranking.
+    ['system_widget', 10001],
     // Ranks 0-1: top integrations used for tests
     ['sonos', 10000],
     ['tplink', 9999],
@@ -30,15 +33,29 @@ const mockAnalyticsData = {
   ]),
 };
 
+// Every test integration is a ranked type, except system_widget (system), which
+// the analytics integrations page — and now the bot — excludes from the ranking.
+const mockIntegrationDetails = Object.fromEntries(
+  Object.keys(mockAnalyticsData.integrations).map((domain) => [
+    domain,
+    { integration_type: domain === 'system_widget' ? 'system' : 'integration' },
+  ]),
+);
+
 describe('LabelBot', () => {
   let handler: LabelBot;
   let mockContext;
 
   beforeEach(async function () {
-    jest.spyOn(global, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockAnalyticsData),
-    } as any);
+    jest.spyOn(global, 'fetch').mockImplementation((url) =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(
+            String(url).includes('integrations.json') ? mockIntegrationDetails : mockAnalyticsData,
+          ),
+      } as any),
+    );
     const analyticsService = new IntegrationAnalyticsService();
     await analyticsService.onModuleInit();
     handler = new LabelBot(analyticsService);
@@ -67,6 +84,21 @@ describe('LabelBot', () => {
       'merging-to-master',
       'integration: mqtt',
     ]);
+  });
+
+  it('does not add Top labels for a non-ranked integration_type', async () => {
+    // system_widget has the highest install count but integration_type "system",
+    // which the analytics ranking excludes, so it must get no Top N labels.
+    mockContext._prFilesCache = [
+      {
+        filename: 'homeassistant/components/system_widget/__init__.py',
+      },
+    ];
+    mockContext.payload.pull_request.base = { ref: 'dev' };
+    await handler.handle(mockContext);
+    assert.ok(!mockContext.scheduledlabels.includes('Top 50'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 100'));
+    assert.ok(!mockContext.scheduledlabels.includes('Top 200'));
   });
 
   it('adds Top 50, Top 100 and Top 200 labels for non-core top 50 integration', async () => {


### PR DESCRIPTION
## Summary

The label bot's `Top 50/100/200` labels don't match where an integration appears on the public analytics integrations page. The bot ranked the raw `integrations` map from `current_data.json` with no filtering, while the analytics site filters by `integration_type` (`integration`/`hub`/`device`/`helper`/`service`) before ranking — excluding `system`/`entity`/`hardware`/`virtual`/`brand` domains.

This fetches the types from `www.home-assistant.io/integrations.json` (the source the site uses) and mirrors its `sortIntegrations` logic: rank only the ranked types, by install count. If either source is unavailable — or yields an empty/unexpected result — the previous ranking is kept rather than ranking on incomplete data.

Fixes #374

## Why the ranks differed

The excluded types include very high-install core components (`automation`, `person`, `script`, `default_config`, `sensor`, `frontend`, `http`, …) that the bot counted but the site does not. They padded the top of the bot's list and pushed real integrations down. Concretely (current data): **23 non-ranked domains rank above `unifiprotect`** in the raw list, so the bot placed it at **#118 → `Top 200`**, while the site (and now the bot) rank it at **#95 → `Top 100`**.

## Behavior change — impact on the labels

Intentional, and the point of #374, but it visibly changes two groups:

- **Excluded-type components lose Top labels.** 14 of the old Top 50 are non-ranked types and no longer get any Top label, e.g. `automation`, `person`, `script`, `default_config`, `scene`, `frontend`, `homeassistant`, `cloud`, `http`, `sensor`, `tts`.
- **Real integrations move up.** The freed slots go to integrations just outside before (old #51–#67): `homekit_controller`, `tplink`, `reolink`, `smartthings`, `webostv`, `music_assistant`, `systemmonitor`, …

So `Top 50` now means the 50 most-installed user-facing integrations, matching the page.

## Test

Mock now serves both sources, plus two new cases: a high-install integration of a non-ranked type gets no Top labels, and an empty `integration_details` response keeps the previous ranking.
