### PR TITLE
RFC: code-owner commands for feature-request discussions

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.const.ts
+++ b/services/bots/src/github-webhook/github-webhook.const.ts
@@ -37,6 +37,7 @@ export enum HomeAssistantRepository {
   COMPANION_HOME_ASSISTANT = 'home-assistant/companion.home-assistant',
   CORE = 'home-assistant/core',
   DEVELOPERS_HOME_ASSISTANT = 'home-assistant/developers.home-assistant',
+  FEATURE_REQUESTS = 'home-assistant/feature-requests',
   FRONTEND = 'home-assistant/frontend',
   HOME_ASSISTANT_IO = 'home-assistant/home-assistant.io',
   INTENTS = 'home-assistant/intents',
@@ -48,6 +49,7 @@ export enum HomeAssistantRepository {
 }
 
 export enum EventType {
+  DISCUSSION_COMMENT_CREATED = 'discussion_comment.created',
   ISSUE_COMMENT_CREATED = 'issue_comment.created',
   ISSUES_LABELED = 'issues.labeled',
   ISSUES_OPENED = 'issues.opened',

--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -10,6 +10,7 @@ import { BlockingLabels } from './handlers/blocking_labels';
 import { BranchLabels } from './handlers/branch_labels';
 import { CodeOwnersMention } from './handlers/code_owners_mention';
 import { DependencyBump } from './handlers/dependency_bump';
+import { DiscussionCommentCommands } from './handlers/discussion_comment_commands/handler';
 import { DocsMissing } from './handlers/docs_missing';
 import { DocsParenting } from './handlers/docs_parenting';
 import { DocsTargetBranch } from './handlers/docs_target_branch';
@@ -38,6 +39,7 @@ import { ValidateCla } from './handlers/validate-cla';
     BranchLabels,
     CodeOwnersMention,
     DependencyBump,
+    DiscussionCommentCommands,
     DocsMissing,
     DocsParenting,
     DocsTargetBranch,

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/answer.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/answer.ts
@@ -1,7 +1,11 @@
 import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
 import { WebhookContext } from '../../../github-webhook.model';
 import { invokerIsCodeOwner, IssueCommentCommandContext } from '../../issue_comment_commands/const';
-import { discussionCommentNodeId, markDiscussionCommentAsAnswer } from '../../../utils/discussion';
+import {
+  addDiscussionReply,
+  discussionCommentNodeId,
+  markDiscussionCommentAsAnswer,
+} from '../../../utils/discussion';
 import { DiscussionCommentCommandBase } from './base';
 
 export class AnswerDiscussionCommentCommand extends DiscussionCommentCommandBase {
@@ -21,21 +25,28 @@ export class AnswerDiscussionCommentCommand extends DiscussionCommentCommandBase
       throw new Error('This discussion category does not accept answers.');
     }
 
-    // Reply → mark its (top-level) parent; otherwise mark the command comment itself.
-    let targetCommentId = comment.node_id;
-    if (comment.parent_id) {
-      const parentNodeId = await discussionCommentNodeId(
+    // The answer is always a top-level comment, so it has to be identified by
+    // replying to it; a standalone command comment has nothing meaningful to mark.
+    if (!comment.parent_id) {
+      await addDiscussionReply(
         context,
-        discussion.number,
-        comment.parent_id,
+        discussion.node_id,
+        comment.node_id,
+        'To mark an answer, reply to the comment you want to mark with `@home-assistant answer`.',
       );
-      if (!parentNodeId) {
-        throw new Error('Could not resolve the parent comment to mark as answer.');
-      }
-      targetCommentId = parentNodeId;
+      return false;
     }
 
-    await markDiscussionCommentAsAnswer(context, targetCommentId);
+    const parentNodeId = await discussionCommentNodeId(
+      context,
+      discussion.number,
+      comment.parent_id,
+    );
+    if (!parentNodeId) {
+      throw new Error('Could not resolve the parent comment to mark as answer.');
+    }
+
+    await markDiscussionCommentAsAnswer(context, parentNodeId);
     return true;
   }
 }

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/answer.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/answer.ts
@@ -1,0 +1,41 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { WebhookContext } from '../../../github-webhook.model';
+import { invokerIsCodeOwner, IssueCommentCommandContext } from '../../issue_comment_commands/const';
+import { discussionCommentNodeId, markDiscussionCommentAsAnswer } from '../../../utils/discussion';
+import { DiscussionCommentCommandBase } from './base';
+
+export class AnswerDiscussionCommentCommand extends DiscussionCommentCommandBase {
+  command = 'answer';
+  invokerType = 'code_owner';
+
+  async handle(
+    context: WebhookContext<DiscussionCommentCreatedEvent>,
+    command: IssueCommentCommandContext,
+  ) {
+    if (!invokerIsCodeOwner(command)) {
+      throw new Error('Only code owners can mark a discussion answer.');
+    }
+
+    const { discussion, comment } = context.payload;
+    if (!discussion.category.is_answerable) {
+      throw new Error('This discussion category does not accept answers.');
+    }
+
+    // Reply → mark its (top-level) parent; otherwise mark the command comment itself.
+    let targetCommentId = comment.node_id;
+    if (comment.parent_id) {
+      const parentNodeId = await discussionCommentNodeId(
+        context,
+        discussion.number,
+        comment.parent_id,
+      );
+      if (!parentNodeId) {
+        throw new Error('Could not resolve the parent comment to mark as answer.');
+      }
+      targetCommentId = parentNodeId;
+    }
+
+    await markDiscussionCommentAsAnswer(context, targetCommentId);
+    return true;
+  }
+}

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/base.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/base.ts
@@ -1,0 +1,14 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { WebhookContext } from '../../../github-webhook.model';
+import { IssueCommentCommandContext } from '../../issue_comment_commands/const';
+
+export abstract class DiscussionCommentCommandBase {
+  command: string;
+  invokerType?: string;
+  requireAdditional?: boolean;
+
+  abstract handle(
+    context: WebhookContext<DiscussionCommentCreatedEvent>,
+    command: IssueCommentCommandContext,
+  ): Promise<boolean>;
+}

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/close.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/close.ts
@@ -1,0 +1,29 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { WebhookContext } from '../../../github-webhook.model';
+import { invokerIsCodeOwner, IssueCommentCommandContext } from '../../issue_comment_commands/const';
+import { closeDiscussion, DiscussionCloseReason } from '../../../utils/discussion';
+import { DiscussionCommentCommandBase } from './base';
+
+const REASONS: { [key: string]: DiscussionCloseReason } = {
+  resolved: 'RESOLVED',
+  outdated: 'OUTDATED',
+  duplicate: 'DUPLICATE',
+};
+
+export class CloseDiscussionCommentCommand extends DiscussionCommentCommandBase {
+  command = 'close';
+  invokerType = 'code_owner';
+
+  async handle(
+    context: WebhookContext<DiscussionCommentCreatedEvent>,
+    command: IssueCommentCommandContext,
+  ) {
+    if (!invokerIsCodeOwner(command)) {
+      throw new Error('Only code owners can close discussions.');
+    }
+
+    const reason = REASONS[(command.additional || '').trim().toLowerCase()] || 'RESOLVED';
+    await closeDiscussion(context, context.payload.discussion.node_id, reason);
+    return true;
+  }
+}

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/close.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/close.ts
@@ -22,7 +22,12 @@ export class CloseDiscussionCommentCommand extends DiscussionCommentCommandBase 
       throw new Error('Only code owners can close discussions.');
     }
 
-    const reason = REASONS[(command.additional || '').trim().toLowerCase()] || 'RESOLVED';
+    const argument = (command.additional || '').trim().toLowerCase();
+    const reason = argument ? REASONS[argument] : 'RESOLVED';
+    if (!reason) {
+      throw new Error(`Unknown close reason: ${argument}`);
+    }
+
     await closeDiscussion(context, context.payload.discussion.node_id, reason);
     return true;
   }

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/rename.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/rename.ts
@@ -1,0 +1,23 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { WebhookContext } from '../../../github-webhook.model';
+import { invokerIsCodeOwner, IssueCommentCommandContext } from '../../issue_comment_commands/const';
+import { updateDiscussionTitle } from '../../../utils/discussion';
+import { DiscussionCommentCommandBase } from './base';
+
+export class RenameDiscussionCommentCommand extends DiscussionCommentCommandBase {
+  command = 'rename';
+  invokerType = 'code_owner';
+  requireAdditional = true;
+
+  async handle(
+    context: WebhookContext<DiscussionCommentCreatedEvent>,
+    command: IssueCommentCommandContext,
+  ) {
+    if (!invokerIsCodeOwner(command)) {
+      throw new Error('Only code owners can rename discussions.');
+    }
+
+    await updateDiscussionTitle(context, context.payload.discussion.node_id, command.additional);
+    return true;
+  }
+}

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/reopen.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/commands/reopen.ts
@@ -1,0 +1,22 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { WebhookContext } from '../../../github-webhook.model';
+import { invokerIsCodeOwner, IssueCommentCommandContext } from '../../issue_comment_commands/const';
+import { reopenDiscussion } from '../../../utils/discussion';
+import { DiscussionCommentCommandBase } from './base';
+
+export class ReopenDiscussionCommentCommand extends DiscussionCommentCommandBase {
+  command = 'reopen';
+  invokerType = 'code_owner';
+
+  async handle(
+    context: WebhookContext<DiscussionCommentCreatedEvent>,
+    command: IssueCommentCommandContext,
+  ) {
+    if (!invokerIsCodeOwner(command)) {
+      throw new Error('Only code owners can reopen discussions.');
+    }
+
+    await reopenDiscussion(context, context.payload.discussion.node_id);
+    return true;
+  }
+}

--- a/services/bots/src/github-webhook/handlers/discussion_comment_commands/handler.ts
+++ b/services/bots/src/github-webhook/handlers/discussion_comment_commands/handler.ts
@@ -1,0 +1,71 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../../github-webhook.const';
+import { WebhookContext } from '../../github-webhook.model';
+import { addDiscussionCommentReaction } from '../../utils/discussion';
+import { fetchIntegrationManifest } from '../../utils/integration';
+import { BaseWebhookHandler } from '../base';
+import { DiscussionCommentCommandBase } from './commands/base';
+
+import { AnswerDiscussionCommentCommand } from './commands/answer';
+import { CloseDiscussionCommentCommand } from './commands/close';
+import { RenameDiscussionCommentCommand } from './commands/rename';
+import { ReopenDiscussionCommentCommand } from './commands/reopen';
+
+const COMMAND_REGEX: RegExp =
+  /^(?<tagged>@home-assistant)\s(?<command>[\w|-]*)(\s(?<additional>.*))?$/;
+
+export const DISCUSSION_COMMENT_COMMANDS: DiscussionCommentCommandBase[] = [
+  new CloseDiscussionCommentCommand(),
+  new ReopenDiscussionCommentCommand(),
+  new AnswerDiscussionCommentCommand(),
+  new RenameDiscussionCommentCommand(),
+];
+
+export class DiscussionCommentCommands extends BaseWebhookHandler {
+  public allowBots = false;
+  public allowedEventTypes = [EventType.DISCUSSION_COMMENT_CREATED];
+  public allowedRepositories = [HomeAssistantRepository.FEATURE_REQUESTS];
+
+  async handle(context: WebhookContext<DiscussionCommentCreatedEvent>) {
+    const input = COMMAND_REGEX.exec(context.payload.comment.body || '')?.groups;
+
+    if (!input) {
+      return;
+    }
+
+    const commentId = context.payload.comment.node_id;
+    const command = DISCUSSION_COMMENT_COMMANDS.find(
+      (command) => command.command === input.command,
+    );
+    if (!command || (command.requireAdditional && !input.additional)) {
+      await addDiscussionCommentReaction(context, commentId, false);
+      return;
+    }
+
+    // The webhook payload carries the discussion's labels, but the base
+    // `Discussion` type does not declare them.
+    const discussionLabels =
+      (context.payload.discussion as { labels?: { name: string }[] }).labels || [];
+    const currentLabels = discussionLabels.map((label) => label.name);
+    const currentIntegrationFromLabels = currentLabels
+      .filter((label) => label.startsWith('integration: '))
+      .map((label) => label.split('integration: ')[1]);
+
+    const integrationManifests = {};
+    for (const integration of currentIntegrationFromLabels) {
+      integrationManifests[integration] = await fetchIntegrationManifest(integration);
+    }
+
+    try {
+      const result = await command.handle(context, {
+        invoker: context.payload.comment.user.login,
+        additional: input.additional,
+        currentLabels,
+        integrationManifests,
+      });
+      await addDiscussionCommentReaction(context, commentId, result);
+    } catch (_) {
+      await addDiscussionCommentReaction(context, commentId, false);
+    }
+  }
+}

--- a/services/bots/src/github-webhook/utils/discussion.ts
+++ b/services/bots/src/github-webhook/utils/discussion.ts
@@ -1,0 +1,86 @@
+import { WebhookContext } from '../github-webhook.model';
+
+export type DiscussionCloseReason = 'RESOLVED' | 'OUTDATED' | 'DUPLICATE';
+
+export const closeDiscussion = (
+  context: WebhookContext<any>,
+  discussionId: string,
+  reason: DiscussionCloseReason,
+): Promise<unknown> =>
+  context.github.graphql(
+    `mutation ($id: ID!, $reason: DiscussionCloseReason!) {
+      closeDiscussion(input: { discussionId: $id, reason: $reason }) { clientMutationId }
+    }`,
+    { id: discussionId, reason },
+  );
+
+export const reopenDiscussion = (
+  context: WebhookContext<any>,
+  discussionId: string,
+): Promise<unknown> =>
+  context.github.graphql(
+    `mutation ($id: ID!) {
+      reopenDiscussion(input: { discussionId: $id }) { clientMutationId }
+    }`,
+    { id: discussionId },
+  );
+
+export const markDiscussionCommentAsAnswer = (
+  context: WebhookContext<any>,
+  commentId: string,
+): Promise<unknown> =>
+  context.github.graphql(
+    `mutation ($id: ID!) {
+      markDiscussionCommentAsAnswer(input: { id: $id }) { clientMutationId }
+    }`,
+    { id: commentId },
+  );
+
+export const updateDiscussionTitle = (
+  context: WebhookContext<any>,
+  discussionId: string,
+  title: string,
+): Promise<unknown> =>
+  context.github.graphql(
+    `mutation ($id: ID!, $title: String!) {
+      updateDiscussion(input: { discussionId: $id, title: $title }) { clientMutationId }
+    }`,
+    { id: discussionId, title },
+  );
+
+export const addDiscussionCommentReaction = (
+  context: WebhookContext<any>,
+  commentId: string,
+  positive: boolean,
+): Promise<unknown> =>
+  context.github.graphql(
+    `mutation ($id: ID!, $content: ReactionContent!) {
+      addReaction(input: { subjectId: $id, content: $content }) { clientMutationId }
+    }`,
+    { id: commentId, content: positive ? 'THUMBS_UP' : 'THUMBS_DOWN' },
+  );
+
+// A discussion comment webhook payload only carries the numeric `parent_id`, not
+// the parent's GraphQL node id (which markDiscussionCommentAsAnswer needs). Resolve
+// it from the discussion's comments. Only top-level comments can be answers, so the
+// parent is always within the first page.
+export const discussionCommentNodeId = async (
+  context: WebhookContext<any>,
+  discussionNumber: number,
+  databaseId: number,
+): Promise<string | undefined> => {
+  const result = (await context.github.graphql(
+    `query ($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        discussion(number: $number) { comments(first: 100) { nodes { id databaseId } } }
+      }
+    }`,
+    { owner: context.repo().owner, name: context.repo().repo, number: discussionNumber },
+  )) as {
+    repository?: { discussion?: { comments?: { nodes?: { id: string; databaseId: number }[] } } };
+  };
+
+  return result?.repository?.discussion?.comments?.nodes?.find(
+    (node) => node.databaseId === databaseId,
+  )?.id;
+};

--- a/services/bots/src/github-webhook/utils/discussion.ts
+++ b/services/bots/src/github-webhook/utils/discussion.ts
@@ -60,27 +60,66 @@ export const addDiscussionCommentReaction = (
     { id: commentId, content: positive ? 'THUMBS_UP' : 'THUMBS_DOWN' },
   );
 
+export const addDiscussionReply = (
+  context: WebhookContext<any>,
+  discussionId: string,
+  replyToId: string,
+  body: string,
+): Promise<unknown> =>
+  context.github.graphql(
+    `mutation ($discussionId: ID!, $replyToId: ID!, $body: String!) {
+      addDiscussionComment(input: { discussionId: $discussionId, replyToId: $replyToId, body: $body }) {
+        clientMutationId
+      }
+    }`,
+    { discussionId, replyToId, body },
+  );
+
 // A discussion comment webhook payload only carries the numeric `parent_id`, not
 // the parent's GraphQL node id (which markDiscussionCommentAsAnswer needs). Resolve
-// it from the discussion's comments. Only top-level comments can be answers, so the
-// parent is always within the first page.
+// it by paging through the discussion's comments until the matching one is found.
 export const discussionCommentNodeId = async (
   context: WebhookContext<any>,
   discussionNumber: number,
   databaseId: number,
 ): Promise<string | undefined> => {
-  const result = (await context.github.graphql(
-    `query ($owner: String!, $name: String!, $number: Int!) {
-      repository(owner: $owner, name: $name) {
-        discussion(number: $number) { comments(first: 100) { nodes { id databaseId } } }
-      }
-    }`,
-    { owner: context.repo().owner, name: context.repo().repo, number: discussionNumber },
-  )) as {
-    repository?: { discussion?: { comments?: { nodes?: { id: string; databaseId: number }[] } } };
-  };
+  let after: string | null = null;
 
-  return result?.repository?.discussion?.comments?.nodes?.find(
-    (node) => node.databaseId === databaseId,
-  )?.id;
+  // Cap the paging to stay bounded even if the API keeps reporting more pages.
+  for (let page = 0; page < 50; page++) {
+    const result = (await context.github.graphql(
+      `query ($owner: String!, $name: String!, $number: Int!, $after: String) {
+        repository(owner: $owner, name: $name) {
+          discussion(number: $number) {
+            comments(first: 100, after: $after) {
+              pageInfo { hasNextPage endCursor }
+              nodes { id databaseId }
+            }
+          }
+        }
+      }`,
+      { owner: context.repo().owner, name: context.repo().repo, number: discussionNumber, after },
+    )) as {
+      repository?: {
+        discussion?: {
+          comments?: {
+            pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+            nodes?: { id: string; databaseId: number }[];
+          };
+        };
+      };
+    };
+
+    const comments = result?.repository?.discussion?.comments;
+    const match = comments?.nodes?.find((node) => node.databaseId === databaseId);
+    if (match) {
+      return match.id;
+    }
+    if (!comments?.pageInfo?.hasNextPage) {
+      return undefined;
+    }
+    after = comments.pageInfo.endCursor;
+  }
+
+  return undefined;
 };

--- a/tests/fixtures/discussion_comment.created.json
+++ b/tests/fixtures/discussion_comment.created.json
@@ -1,0 +1,25 @@
+{
+  "action": "created",
+  "discussion": {
+    "number": 972,
+    "node_id": "D_discussion_972",
+    "title": "Feature request",
+    "category": {
+      "is_answerable": true
+    },
+    "labels": [{ "name": "integration: awesome" }]
+  },
+  "comment": {
+    "id": 555,
+    "node_id": "DC_comment_555",
+    "body": "",
+    "parent_id": null,
+    "user": { "login": "test" }
+  },
+  "repository": {
+    "name": "feature-requests",
+    "full_name": "home-assistant/feature-requests",
+    "owner": { "login": "home-assistant" }
+  },
+  "sender": { "type": "User", "login": "test" }
+}

--- a/tests/services/bots/github-webhook/handlers/discussion_comment_commands.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/discussion_comment_commands.spec.ts
@@ -59,6 +59,21 @@ describe('DiscussionCommentCommands', () => {
       );
     });
 
+    it('rejects an unknown reason', async () => {
+      mockContext.payload.comment.body = '@home-assistant close foo';
+      mockContext.payload.comment.user.login = 'test';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).not.toHaveBeenCalledWith(
+        expect.stringContaining('closeDiscussion'),
+        expect.anything(),
+      );
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('addReaction'),
+        expect.objectContaining({ content: 'THUMBS_DOWN' }),
+      );
+    });
+
     it('not by codeowner', async () => {
       mockContext.payload.comment.body = '@home-assistant close';
       mockContext.payload.comment.user.login = 'other';
@@ -101,15 +116,19 @@ describe('DiscussionCommentCommands', () => {
   });
 
   describe('command: answer', () => {
-    it('marks the command comment when it is top-level', async () => {
+    it('replies with guidance and does not mark when used top-level', async () => {
       mockContext.payload.comment.body = '@home-assistant answer';
       mockContext.payload.comment.user.login = 'test';
       mockContext.payload.comment.parent_id = null;
       await handler.handle(mockContext);
 
       expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('addDiscussionComment'),
+        expect.objectContaining({ replyToId: 'DC_comment_555' }),
+      );
+      expect(graphqlMock(mockContext)).not.toHaveBeenCalledWith(
         expect.stringContaining('markDiscussionCommentAsAnswer'),
-        expect.objectContaining({ id: 'DC_comment_555' }),
+        expect.anything(),
       );
     });
 
@@ -119,10 +138,15 @@ describe('DiscussionCommentCommands', () => {
       mockContext.payload.comment.parent_id = 7;
       graphqlMock(mockContext).mockImplementation((query: string) =>
         Promise.resolve(
-          query.includes('comments(first: 100)')
+          query.includes('pageInfo')
             ? {
                 repository: {
-                  discussion: { comments: { nodes: [{ id: 'PARENT_NODE', databaseId: 7 }] } },
+                  discussion: {
+                    comments: {
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                      nodes: [{ id: 'PARENT_NODE', databaseId: 7 }],
+                    },
+                  },
                 },
               }
             : {},

--- a/tests/services/bots/github-webhook/handlers/discussion_comment_commands.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/discussion_comment_commands.spec.ts
@@ -1,0 +1,175 @@
+import { DiscussionCommentCreatedEvent } from '@octokit/webhooks-types';
+import { WebhookContext } from '../../../../../services/bots/src/github-webhook/github-webhook.model';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import { loadJsonFixture } from '../../../../utils/fixture';
+import { DiscussionCommentCommands } from '../../../../../services/bots/src/github-webhook/handlers/discussion_comment_commands/handler';
+import { EventType } from '../../../../../services/bots/src/github-webhook/github-webhook.const';
+
+const graphqlMock = (context: WebhookContext<DiscussionCommentCreatedEvent>) =>
+  context.github.graphql as unknown as jest.Mock;
+
+describe('DiscussionCommentCommands', () => {
+  let handler: DiscussionCommentCommands;
+  let mockContext: WebhookContext<DiscussionCommentCreatedEvent>;
+  let mockedFetch: ReturnType<typeof jest.fn>;
+
+  beforeEach(function () {
+    mockedFetch = jest.fn(global.fetch);
+    mockedFetch.mockImplementation(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ codeowners: ['@test'] }),
+      } as unknown as Response),
+    );
+    (global.fetch as unknown) = mockedFetch;
+    handler = new DiscussionCommentCommands();
+    mockContext = mockWebhookContext<DiscussionCommentCreatedEvent>({
+      eventType: EventType.DISCUSSION_COMMENT_CREATED,
+      payload: loadJsonFixture<DiscussionCommentCreatedEvent>('discussion_comment.created'),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('command: close', () => {
+    it('by codeowner defaults to RESOLVED', async () => {
+      mockContext.payload.comment.body = '@home-assistant close';
+      mockContext.payload.comment.user.login = 'test';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('closeDiscussion'),
+        expect.objectContaining({ id: 'D_discussion_972', reason: 'RESOLVED' }),
+      );
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('addReaction'),
+        expect.objectContaining({ content: 'THUMBS_UP' }),
+      );
+    });
+
+    it('by codeowner with a reason', async () => {
+      mockContext.payload.comment.body = '@home-assistant close duplicate';
+      mockContext.payload.comment.user.login = 'test';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('closeDiscussion'),
+        expect.objectContaining({ reason: 'DUPLICATE' }),
+      );
+    });
+
+    it('not by codeowner', async () => {
+      mockContext.payload.comment.body = '@home-assistant close';
+      mockContext.payload.comment.user.login = 'other';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).not.toHaveBeenCalledWith(
+        expect.stringContaining('closeDiscussion'),
+        expect.anything(),
+      );
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('addReaction'),
+        expect.objectContaining({ content: 'THUMBS_DOWN' }),
+      );
+    });
+
+    it('not on a discussion without an integration label', async () => {
+      mockContext.payload.comment.body = '@home-assistant close';
+      mockContext.payload.comment.user.login = 'test';
+      (mockContext.payload.discussion as { labels?: unknown[] }).labels = [];
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).not.toHaveBeenCalledWith(
+        expect.stringContaining('closeDiscussion'),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('command: reopen', () => {
+    it('by codeowner', async () => {
+      mockContext.payload.comment.body = '@home-assistant reopen';
+      mockContext.payload.comment.user.login = 'test';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('reopenDiscussion'),
+        expect.objectContaining({ id: 'D_discussion_972' }),
+      );
+    });
+  });
+
+  describe('command: answer', () => {
+    it('marks the command comment when it is top-level', async () => {
+      mockContext.payload.comment.body = '@home-assistant answer';
+      mockContext.payload.comment.user.login = 'test';
+      mockContext.payload.comment.parent_id = null;
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('markDiscussionCommentAsAnswer'),
+        expect.objectContaining({ id: 'DC_comment_555' }),
+      );
+    });
+
+    it('marks the parent comment when it is a reply', async () => {
+      mockContext.payload.comment.body = '@home-assistant answer';
+      mockContext.payload.comment.user.login = 'test';
+      mockContext.payload.comment.parent_id = 7;
+      graphqlMock(mockContext).mockImplementation((query: string) =>
+        Promise.resolve(
+          query.includes('comments(first: 100)')
+            ? {
+                repository: {
+                  discussion: { comments: { nodes: [{ id: 'PARENT_NODE', databaseId: 7 }] } },
+                },
+              }
+            : {},
+        ),
+      );
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('markDiscussionCommentAsAnswer'),
+        expect.objectContaining({ id: 'PARENT_NODE' }),
+      );
+    });
+
+    it('does nothing in a non-answerable category', async () => {
+      mockContext.payload.comment.body = '@home-assistant answer';
+      mockContext.payload.comment.user.login = 'test';
+      mockContext.payload.discussion.category.is_answerable = false;
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).not.toHaveBeenCalledWith(
+        expect.stringContaining('markDiscussionCommentAsAnswer'),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('command: rename', () => {
+    it('by codeowner with a title', async () => {
+      mockContext.payload.comment.body = '@home-assistant rename New title';
+      mockContext.payload.comment.user.login = 'test';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).toHaveBeenCalledWith(
+        expect.stringContaining('updateDiscussion'),
+        expect.objectContaining({ title: 'New title' }),
+      );
+    });
+
+    it('without a title', async () => {
+      mockContext.payload.comment.body = '@home-assistant rename';
+      mockContext.payload.comment.user.login = 'test';
+      await handler.handle(mockContext);
+
+      expect(graphqlMock(mockContext)).not.toHaveBeenCalledWith(
+        expect.stringContaining('updateDiscussion'),
+        expect.anything(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
> **RFC / draft.** This proposes letting integration code owners manage their feature requests, and it cannot run until a GitHub App change is made (see Prerequisite). Opening as a draft to get a decision before investing further.

## Idea

Home Assistant's org-level discussions (https://github.com/orgs/home-assistant/discussions) are powered by the `home-assistant/feature-requests` source repository, where integration feature requests carry an `integration: <domain>` label. Today, when a feature request is implemented, the integration code owner cannot resolve the discussion — unlike issues/PRs, where `@home-assistant close` works.

This adds a `discussion_comment.created` handler (scoped to `feature-requests`) with code-owner commands that mirror the issue/PR ones, so the owner who implements a request can close it (and the matching counterparts):

- `close [resolved|outdated|duplicate]` (default `resolved`) → `closeDiscussion`
- `reopen` → `reopenDiscussion`
- `answer` (used as a reply) → `markDiscussionCommentAsAnswer` on the replied-to comment
- `rename <new title>` → `updateDiscussion`

Ownership is verified from the discussion's `integration: <domain>` label against the integration manifest's `codeowners`, reusing the existing `invokerIsCodeOwner` check. Feedback is a 👍/👎 reaction, like the issue/PR commands.

## ⚠️ Prerequisite (why this is a draft)

This is inert until the bot's GitHub App is granted **Discussions: Read & write** and subscribed to the **`discussion_comment`** webhook event — an org-admin action and a privilege-surface change, outside this repo.

## Open questions for maintainers

1. **Is this wanted?** Should per-integration code owners be able to close / mark-answer / rename org feature-request discussions, or should that stay with org triagers?
2. **Scope:** Is `rename` desirable, or should this stay close/reopen/answer only?
3. **`answer` UX:** it only acts when used as a reply (marks the parent); a top-level invocation currently replies with a one-line hint. Prefer just a 👎 reaction instead?

## Implementation notes

- New `handlers/discussion_comment_commands/` (handler + base + close/reopen/answer/rename), `utils/discussion.ts` (GraphQL mutations — discussions are GraphQL-only), `EventType.DISCUSSION_COMMENT_CREATED`, `HomeAssistantRepository.FEATURE_REQUESTS`, module registration.
- Multiple `integration:` labels on one discussion → rejected (single-owner), same as the issue `close`/`rename` commands.
- The `answer` reply path resolves the parent comment's node id by paging the discussion comments (bounded).

## Test

`discussion_comment_commands.spec.ts` covers each command (close reason default/parse/reject, reopen, answer reply vs top-level guidance, non-answerable guard, rename with/without title) plus the code-owner and integration-label gates.
