### PR TITLE
Draft new integration PRs that add diagnostics

### DIFF
--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -41,8 +41,8 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
   }
 
   /**
-   * When a new-integration label is added, check if the PR contains multiple platforms
-   * or a brand sub-folder. If so, request changes with a combined message.
+   * When a new-integration label is added, check if the PR contains multiple platforms,
+   * diagnostics support, or a brand sub-folder. If so, request changes with a combined message.
    */
   async handle(context: WebhookContext<PullRequestLabeledEvent>) {
     if (context.payload.label?.name !== 'new-integration') {

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -20,6 +20,16 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     return 'When adding new integrations, limit included platforms to a single platform. Please reduce this PR to a single platform. See the [review process](https://developers.home-assistant.io/docs/review-process/#home-assistant-core) for more details.';
   }
 
+  private getDiagnosticsIssue(parsed: ParsedPath[]): string | undefined {
+    const hasDiagnostics = parsed.some((path) => path.type === 'diagnostics');
+
+    if (!hasDiagnostics) {
+      return undefined;
+    }
+
+    return 'When adding new integrations, limit the initial PR to a single platform and basic functionality. This PR adds diagnostics, please remove it and add it in a follow-up PR. See the [review process](https://developers.home-assistant.io/docs/review-process/#home-assistant-core) for more details.';
+  }
+
   private getBrandIssue(parsed: ParsedPath[]): string | undefined {
     const hasBrandFolder = parsed.some((path) => path.type === 'brand');
 
@@ -42,7 +52,7 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     const pullRequestFiles = await fetchPullRequestFilesFromContext(context);
     const parsed = pullRequestFiles.map((file) => new ParsedPath(file));
 
-    const issueCheckers = [this.getPlatformIssue, this.getBrandIssue];
+    const issueCheckers = [this.getPlatformIssue, this.getDiagnosticsIssue, this.getBrandIssue];
     const issues = issueCheckers
       .map((checker) => checker.call(this, parsed))
       .filter((issue): issue is string => Boolean(issue));

--- a/services/bots/src/github-webhook/utils/parse_path.ts
+++ b/services/bots/src/github-webhook/utils/parse_path.ts
@@ -17,6 +17,7 @@ export class ParsedPath {
     | 'services'
     | 'component'
     | 'platform'
+    | 'diagnostics'
     | 'brand' = null;
   public component: null | string = null;
   public platform: null | string = null;
@@ -62,6 +63,8 @@ export class ParsedPath {
       this.type = 'brand';
     } else if (filename === 'services.yaml') {
       this.type = 'services';
+    } else if (filename === 'diagnostics') {
+      this.type = 'diagnostics';
     } else if (entityComponents.has(filename)) {
       this.type = 'platform';
       this.platform = filename;

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -64,6 +64,23 @@ describe('NewIntegrationsHandler', () => {
     assert.ok(!call.body.includes('brand'));
   });
 
+  it('requests changes when the PR adds diagnostics', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: 'homeassistant/components/my_integration/diagnostics.py' },
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('diagnostics'));
+    assert.ok(!call.body.includes('limit included platforms'));
+    assert.ok(!call.body.includes('brand'));
+  });
+
   it('requests changes when the PR contains a brand folder', async () => {
     mockContext._prFilesCache = [
       { filename: 'homeassistant/components/my_integration/__init__.py' },

--- a/tests/services/bots/github-webhook/utils/parse_path.spec.ts
+++ b/tests/services/bots/github-webhook/utils/parse_path.spec.ts
@@ -12,6 +12,10 @@ describe('ParsedPath', () => {
       'homeassistant/components/demo/switch.py',
       { core: true, platform: 'switch', component: 'demo', type: 'platform' },
     ],
+    [
+      'homeassistant/components/demo/diagnostics.py',
+      { core: true, platform: null, component: 'demo', type: 'diagnostics' },
+    ],
   ])('%s', (filename: string, results: Record<string, any>) => {
     for (const [key, value] of Object.entries(results)) {
       const parsedPath = new ParsedPath({ filename } as ListPullRequestFiles[0]);


### PR DESCRIPTION
Extend the new-integration "single platform rule" so a PR is also flagged (and consequently put back to draft via the review drafter) when it adds diagnostics support, since the initial integration PR should be limited to a single platform and basic functionality.