### PR TITLE
Comment on pull requests that do not follow the template

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -25,6 +25,7 @@ import { MergeConflictChecker } from './handlers/merge_conflict';
 import { MonthOfWTH } from './handlers/month_of_wth';
 import { NewIntegrationsHandler } from './handlers/new_integrations';
 import { PlatinumReview } from './handlers/platinum_review';
+import { PrTemplate } from './handlers/pr_template';
 import { QualityScaleLabeler } from './handlers/quality_scale';
 import { RequiredLabels } from './handlers/required_labels';
 import { ReviewDrafter } from './handlers/review_drafter';
@@ -53,6 +54,7 @@ import { ValidateCla } from './handlers/validate-cla';
     MonthOfWTH,
     NewIntegrationsHandler,
     PlatinumReview,
+    PrTemplate,
     QualityScaleLabeler,
     RequiredLabels,
     ReviewDrafter,

--- a/services/bots/src/github-webhook/handlers/pr_template.ts
+++ b/services/bots/src/github-webhook/handlers/pr_template.ts
@@ -1,0 +1,206 @@
+import { PullRequest, PullRequestOpenedEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { BaseWebhookHandler } from './base';
+
+const TEMPLATE_PATH = '.github/PULL_REQUEST_TEMPLATE.md';
+const TEMPLATE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// The template is near-static, so cache it per repository+ref across events
+// (the service is long-lived). Only successful reads are cached; failures fall
+// through so a transient error does not suppress the check for the whole TTL.
+const templateCache = new Map<string, { content: string; expires: number }>();
+
+/** Test seam: drop the cached templates so specs stay isolated. */
+export const resetTemplateCache = (): void => templateCache.clear();
+
+// Up to three leading spaces are allowed before an ATX heading; GitHub still
+// renders those as headings.
+const HEADING_LINE = /^ {0,3}#{1,6}\s+(.*\S)/;
+const TASK_LINE = /^\s*-\s?\[[ xX]?\]\s+(.*\S)\s*$/;
+
+/**
+ * Run a callback over the lines of a markdown document, skipping HTML comment
+ * blocks (`<!-- … -->`). Used to read headers and checkboxes the same way.
+ */
+const forEachContentLine = (markdown: string, visit: (line: string) => void): void => {
+  let inComment = false;
+  for (const line of markdown.split('\n')) {
+    if (!inComment && line.includes('<!--')) {
+      inComment = !line.includes('-->');
+      continue;
+    }
+    if (inComment) {
+      if (line.includes('-->')) inComment = false;
+      continue;
+    }
+    visit(line);
+  }
+};
+
+/** Collect the normalized `##` section headers of a markdown document. */
+const sectionHeaders = (markdown: string): Set<string> => {
+  const headers = new Set<string>();
+  forEachContentLine(markdown, (line) => {
+    const match = line.match(HEADING_LINE);
+    if (match) headers.add(match[1].replace(/\s+/g, ' ').trim().toLowerCase());
+  });
+  return headers;
+};
+
+// Normalize a checkbox item for matching: strip markdown links, code and
+// emphasis markers (so the same item matches whatever formatting the body
+// uses), collapse whitespace and drop trailing punctuation.
+const normalizeItem = (text: string): string =>
+  text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // inline links [text](url) -> text
+    .replace(/\[([^\]]+)\]\[[^\]]*\]/g, '$1') // reference links [text][ref] -> text
+    .replace(/[`*_]/g, '') // code / bold / italic markers
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[.:]$/, '')
+    .toLowerCase();
+
+/**
+ * Every checkbox the template expects to be kept: all `- [ ]` items except the
+ * conditional ones (those under an "If …:" / "To …:" intro, which may be
+ * dropped when they don't apply). The template says to tick the applicable
+ * boxes rather than delete any, so all of these should be present. Derived from
+ * the live template, so it tracks the template automatically. Returns the
+ * original item text plus a normalized signature.
+ */
+const requiredCheckboxes = (templateMd: string): { text: string; sig: string }[] => {
+  const items: { text: string; sig: string }[] = [];
+  let conditional = false;
+
+  forEachContentLine(templateMd, (line) => {
+    if (HEADING_LINE.test(line)) {
+      conditional = false; // a new section resets the conditional scope
+      return;
+    }
+    const task = line.match(TASK_LINE);
+    if (task) {
+      if (!conditional) items.push({ text: task[1].trim(), sig: normalizeItem(task[1]) });
+      return;
+    }
+    if (line.trim() === '') return;
+    // A prose line ending in ":" introduces a conditional block ("If …:").
+    if (line.trim().endsWith(':')) conditional = true;
+  });
+
+  return items;
+};
+
+/** Normalized checkbox items present in a PR description. */
+const bodyTaskItems = (bodyMd: string): string[] => {
+  const items: string[] = [];
+  forEachContentLine(bodyMd, (line) => {
+    const task = line.match(TASK_LINE);
+    if (task) items.push(normalizeItem(task[1]));
+  });
+  return items;
+};
+
+export class PrTemplate extends BaseWebhookHandler {
+  public allowBots = false;
+  public allowedEventTypes = [EventType.PULL_REQUEST_OPENED];
+  public allowedRepositories = [HomeAssistantRepository.CORE];
+
+  /**
+   * Fetch the base-branch template, cached per repo+ref (the service is
+   * long-lived). Returns null — meaning "do nothing" — when the template can't
+   * be read or has no parseable headers. Only usable templates are cached, so a
+   * transient bad read is retried on the next PR rather than poisoning the cache.
+   */
+  private async fetchTemplate(
+    context: WebhookContext<PullRequestOpenedEvent>,
+    ref: string,
+  ): Promise<string | null> {
+    const cacheKey = `${context.repository}@${ref}`;
+    const cached = templateCache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) {
+      return cached.content;
+    }
+
+    let content: string;
+    try {
+      const response = await context.github.repos.getContent(
+        context.repo({ path: TEMPLATE_PATH, ref }),
+      );
+      // @ts-ignore - getContent returns a union; a file response has `content`
+      content = Buffer.from(response.data.content, 'base64').toString();
+    } catch {
+      return null;
+    }
+
+    if (sectionHeaders(content).size === 0) {
+      return null;
+    }
+
+    templateCache.set(cacheKey, { content, expires: Date.now() + TEMPLATE_CACHE_TTL_MS });
+    return content;
+  }
+
+  /**
+   * When a pull request is opened, check whether its description follows the
+   * repository pull request template. Two checks, in order:
+   *
+   *  1. If the description shares no `##` section header with the template, it
+   *     was replaced wholesale — comment asking to use the template.
+   *  2. Otherwise, if any of the template's non-conditional checkboxes were
+   *     removed — comment listing the missing ones.
+   *
+   * Both checks are deliberately conservative and fail open.
+   */
+  async handle(context: WebhookContext<PullRequestOpenedEvent>) {
+    const pullRequest = context.payload.pull_request as PullRequest;
+
+    const templateContent = await this.fetchTemplate(context, pullRequest.base.ref);
+    if (templateContent === null) {
+      return;
+    }
+
+    const body = pullRequest.body || '';
+    const author = pullRequest.user.login;
+    const templateUrl = `https://github.com/${context.repository}/blob/${pullRequest.base.ref}/${TEMPLATE_PATH}`;
+
+    // (1) Did the description use the template at all? (a shared section header)
+    const templateHeaders = sectionHeaders(templateContent);
+    const usesTemplate = [...sectionHeaders(body)].some((header) => templateHeaders.has(header));
+
+    if (!usesTemplate) {
+      // The description shares no section with the template: it was replaced
+      // wholesale. Ask the author to use the template.
+      context.scheduleIssueComment({
+        handler: 'PrTemplate',
+        comment: `Hi @${author}, thanks for the contribution!
+
+It looks like the description of this pull request doesn't follow our [pull request template](${templateUrl}). The template captures the type of change, any breaking-change notes and the checklist reviewers rely on, so filling it in helps get your PR reviewed faster.
+
+Could you update the description above to use the template? You can edit it at any time. Thanks!`,
+      });
+      return;
+    }
+
+    // (2) Were any of the template's checkboxes deleted? (tick, don't remove.)
+    // Match with startsWith so an item the author annotated still counts.
+    const items = bodyTaskItems(body);
+    const missing = requiredCheckboxes(templateContent).filter(
+      (item) => !items.some((present) => present.startsWith(item.sig)),
+    );
+    if (missing.length === 0) {
+      return;
+    }
+
+    context.scheduleIssueComment({
+      handler: 'PrTemplate',
+      comment: `Hi @${author}, thanks for the contribution!
+
+Some checkboxes from the [pull request template](${templateUrl}) appear to be missing from the description. The template asks you to keep them all and tick the ones that apply, rather than deleting lines. Missing:
+
+${missing.map((item) => `- [ ] ${item.text}`).join('\n')}
+
+Could you add them back? Thanks!`,
+    });
+  }
+}

--- a/tests/services/bots/github-webhook/handlers/pr_template.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/pr_template.spec.ts
@@ -1,0 +1,218 @@
+// @ts-nocheck
+import * as assert from 'assert';
+import { WebhookContext } from '../../../../../services/bots/src/github-webhook/github-webhook.model';
+import {
+  PrTemplate,
+  resetTemplateCache,
+} from '../../../../../services/bots/src/github-webhook/handlers/pr_template';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import { loadJsonFixture } from '../../../../utils/fixture';
+
+// Required checkboxes = 2 type-of-change options + 2 checklist items. The
+// manifest item is conditional (under an "If …:" intro) and not required.
+const TEMPLATE = `<!--
+  You are amazing! Thanks for contributing to our project!
+-->
+## Proposed change
+
+## Type of change
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (which adds functionality to an existing integration)
+
+## Checklist
+
+- [ ] I understand the code I am submitting and can explain how it works.
+- [ ] I have followed the [development checklist][dev-checklist]
+
+If the code communicates with devices, web services, or third-party tools:
+
+- [ ] The manifest file has all fields filled out correctly.
+`;
+
+// Replaced the template wholesale with its own structure (mirrors core#172332).
+const CUSTOM_BODY = `## Description
+
+Adds support for ALLNET MSR devices via their local JSON API.
+
+## Supported entities
+`;
+
+// Uses the template and keeps every required checkbox (the conditional manifest
+// item is legitimately omitted; the dev-checklist item uses a plain-text form).
+const COMPLIANT_BODY = `## Proposed change
+
+Fixes a bug.
+
+## Type of change
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [x] New feature (which adds functionality to an existing integration)
+
+## Checklist
+
+- [x] I understand the code I am submitting and can explain how it works.
+- [x] I have followed the development checklist
+`;
+
+const makeContext = ({
+  body,
+  getContent = jest.fn().mockResolvedValue({
+    data: { content: Buffer.from(TEMPLATE).toString('base64') },
+  }),
+}: {
+  body: string | null;
+  getContent?: jest.Mock;
+}): WebhookContext<any> =>
+  mockWebhookContext({
+    eventType: 'pull_request.opened',
+    payload: loadJsonFixture('pull_request.opened', {
+      pull_request: { body, base: { ref: 'dev' }, user: { login: 'octocat' } },
+    }),
+    github: { repos: { getContent } },
+  });
+
+describe('PrTemplate', () => {
+  let handler: PrTemplate;
+
+  beforeEach(() => {
+    handler = new PrTemplate();
+    resetTemplateCache();
+  });
+
+  it('comments when the description shares no header with the template', async () => {
+    const context = makeContext({ body: CUSTOM_BODY });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 1);
+    const [scheduled] = context.scheduledComments;
+    assert.strictEqual(scheduled.handler, 'PrTemplate');
+    assert.ok(scheduled.comment.includes('pull request template'));
+    assert.ok(scheduled.comment.includes('/.github/PULL_REQUEST_TEMPLATE.md'));
+    assert.ok(scheduled.comment.includes('@octocat'));
+  });
+
+  it('stays silent when the template is used and every required checkbox is kept', async () => {
+    // Also covers: conditional item omitted, and a reference-link item written
+    // as plain text — both must still be considered present.
+    const context = makeContext({ body: COMPLIANT_BODY });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 0);
+  });
+
+  it('comments listing the missing checkboxes when one is removed', async () => {
+    const context = makeContext({
+      body: `## Proposed change
+
+Fixes a bug.
+
+## Type of change
+
+- [x] Bugfix (non-breaking change which fixes an issue)
+
+## Checklist
+
+- [x] I understand the code I am submitting and can explain how it works.
+- [x] I have followed the development checklist
+`,
+    });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 1);
+    const [scheduled] = context.scheduledComments;
+    assert.ok(scheduled.comment.includes('missing'));
+    assert.ok(
+      scheduled.comment.includes(
+        'New feature (which adds functionality to an existing integration)',
+      ),
+    );
+    // A kept box must not be listed as missing.
+    assert.ok(!scheduled.comment.includes('I understand the code I am submitting'));
+  });
+
+  it('treats an annotated checkbox as present (startsWith match)', async () => {
+    const context = makeContext({
+      body: `## Proposed change
+
+Fixes a bug.
+
+## Type of change
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [x] New feature (which adds functionality to an existing integration)
+
+## Checklist
+
+- [x] I understand the code I am submitting and can explain how it works. (done in commit abc123)
+- [x] I have followed the development checklist
+`,
+    });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 0);
+  });
+
+  it('stays silent when template headers are indented (GitHub still renders them)', async () => {
+    const context = makeContext({
+      body:
+        '  ## Proposed change\n\n  Fixes a bug.\n\n  ## Type of change\n\n' +
+        '  - [ ] Bugfix (non-breaking change which fixes an issue)\n' +
+        '  - [x] New feature (which adds functionality to an existing integration)\n\n' +
+        '  ## Checklist\n\n' +
+        '  - [x] I understand the code I am submitting and can explain how it works.\n' +
+        '  - [x] I have followed the development checklist\n',
+    });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 0);
+  });
+
+  it('comments on an empty description (template is mandatory)', async () => {
+    const context = makeContext({ body: null });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 1);
+  });
+
+  it('fails open when the template cannot be fetched', async () => {
+    const context = makeContext({
+      body: CUSTOM_BODY,
+      getContent: jest.fn().mockRejectedValue(new Error('404 not found')),
+    });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 0);
+  });
+
+  it('fetches the template only once for the same repo and ref (TTL cache)', async () => {
+    const getContent = jest.fn().mockResolvedValue({
+      data: { content: Buffer.from(TEMPLATE).toString('base64') },
+    });
+
+    await handler.handle(makeContext({ body: CUSTOM_BODY, getContent }));
+    await handler.handle(makeContext({ body: CUSTOM_BODY, getContent }));
+
+    expect(getContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open when the template has no recognizable headers', async () => {
+    const context = makeContext({
+      body: CUSTOM_BODY,
+      getContent: jest.fn().mockResolvedValue({
+        data: { content: Buffer.from('just some text, no headers').toString('base64') },
+      }),
+    });
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 0);
+  });
+});

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -81,6 +81,7 @@ describe('GithubWebhookModule', () => {
         'MergeConflictChecker',
         'MonthOfWTH',
         'PlatinumReview',
+        'PrTemplate',
         'ValidateCla',
       ],
       payload: {


### PR DESCRIPTION
## What

Adds a `PrTemplate` webhook handler. When a **core** pull request is opened, it
checks the description against the repository's *live* pull request template
(fetched from the PR's base branch) and leaves a friendly comment when:

1. the description shares **no** `##` section header with the template — it was
   replaced wholesale; or
2. the template is used but one or more of its **non-conditional** checkboxes
   were removed (the template asks to tick the boxes that apply, not delete them).

## Why

Some PRs replace the template with their own structure or trim out parts of it,
dropping the *Type of change*, breaking-change notes and checklist reviewers rely
on — and nothing currently nudges the author to fill the template back in.

## How it works

- **Template-driven**: the expected headers and checkboxes are derived from the
  live template, so it tracks template changes automatically.
- **Conservative**: check 1 fires only on *zero* header overlap; check 2 excludes
  conditional (`If …:`) items and matches with `startsWith` plus link/formatting
  normalization, so an annotated or re-linked item still counts as present.
- **Fails open**: any problem fetching or parsing the template results in no action.
- The template is TTL-cached (1 h) per repo+ref; only usable templates are cached.
- Runs on `pull_request.opened` only, skips bot authors, and comments on drafts
  too (the template is expected regardless of size or draft state).

## Validation

Dry-run of the handler against **all 876** open non-bot core PRs:

| | replaced template | checkbox removed |
|---|---|---|
| all open (876) | 19 | 132 |
| recently opened (55) | 0 | 3 |

The high "checkbox removed" count over all open PRs is inflated by older PRs
matched against today's template; on recently opened PRs — which used the current
template — it is ~5 %, and every flag was a genuine deletion (no false positives
after normalization + `startsWith`).

Tests cover both checks, conditional-item exclusion, link normalization,
annotated items, indented headers, the TTL cache and the fail-open paths.
