### PR TITLE
Comment guidance on new-integration pull requests

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.module.ts
+++ b/services/bots/src/github-webhook/github-webhook.module.ts
@@ -25,6 +25,7 @@ import { MergeConflictChecker } from './handlers/merge_conflict';
 import { MonthOfWTH } from './handlers/month_of_wth';
 import { NewIntegrationsHandler } from './handlers/new_integrations';
 import { PlatinumReview } from './handlers/platinum_review';
+import { PrContext } from './handlers/pr_context';
 import { QualityScaleLabeler } from './handlers/quality_scale';
 import { RequiredLabels } from './handlers/required_labels';
 import { ReviewDrafter } from './handlers/review_drafter';
@@ -53,6 +54,7 @@ import { ValidateCla } from './handlers/validate-cla';
     MonthOfWTH,
     NewIntegrationsHandler,
     PlatinumReview,
+    PrContext,
     QualityScaleLabeler,
     RequiredLabels,
     ReviewDrafter,

--- a/services/bots/src/github-webhook/handlers/pr_context.ts
+++ b/services/bots/src/github-webhook/handlers/pr_context.ts
@@ -1,0 +1,38 @@
+import { PullRequest, PullRequestLabeledEvent } from '@octokit/webhooks-types';
+import { EventType, HomeAssistantRepository } from '../github-webhook.const';
+import { WebhookContext } from '../github-webhook.model';
+import { BaseWebhookHandler } from './base';
+
+// Guidance comments posted when a pull request receives one of these labels.
+const PR_CONTEXT: Record<string, string> = {
+  'new-integration': `Thanks for the contribution! While this waits for review, it may help to self-check a few things reviewers will look at:
+
+- **Docs**: does it follow the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)? In particular, all device/API communication should live in a [separate library on PyPI](https://developers.home-assistant.io/docs/creating_component_code_review) referenced in the manifest, not inside the integration.
+- **Quality scale**: since this targets Bronze, going through the [quality-scale rules](https://developers.home-assistant.io/docs/integration_quality_scale_index/) and ticking them off in \`quality_scale.yaml\` avoids surprises later.
+- **Scope**: a new integration should add a single platform to keep the PR small and reviewable — further platforms can follow in separate PRs.`,
+};
+
+export class PrContext extends BaseWebhookHandler {
+  public allowedEventTypes = [EventType.PULL_REQUEST_LABELED];
+  public allowedRepositories = [HomeAssistantRepository.CORE];
+
+  /**
+   * When a pull request gets a label we have guidance for, leave that guidance
+   * as a comment — e.g. pointing new-integration authors at the docs, quality
+   * scale and single-platform guideline while their PR waits for review.
+   */
+  async handle(context: WebhookContext<PullRequestLabeledEvent>) {
+    const labelName = context.payload.label?.name;
+    const message = labelName ? PR_CONTEXT[labelName] : undefined;
+    if (!message) {
+      return;
+    }
+
+    const author = (context.payload.pull_request as PullRequest).user.login;
+
+    context.scheduleIssueComment({
+      handler: 'PrContext',
+      comment: `@${author} ${message}`,
+    });
+  }
+}

--- a/tests/services/bots/github-webhook/handlers/pr_context.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/pr_context.spec.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+import * as assert from 'assert';
+import { WebhookContext } from '../../../../../services/bots/src/github-webhook/github-webhook.model';
+import { PrContext } from '../../../../../services/bots/src/github-webhook/handlers/pr_context';
+import { mockWebhookContext } from '../../../../utils/test_context';
+import { loadJsonFixture } from '../../../../utils/fixture';
+
+const makeContext = (labelName: string): WebhookContext<any> =>
+  mockWebhookContext({
+    eventType: 'pull_request.labeled',
+    payload: loadJsonFixture('pull_request.opened', {
+      label: { name: labelName },
+      pull_request: { user: { login: 'octocat' } },
+    }),
+  });
+
+describe('PrContext', () => {
+  let handler: PrContext;
+
+  beforeEach(() => {
+    handler = new PrContext();
+  });
+
+  it('comments with the guidance for the new-integration label', async () => {
+    const context = makeContext('new-integration');
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 1);
+    const [scheduled] = context.scheduledComments;
+    assert.strictEqual(scheduled.handler, 'PrContext');
+    assert.ok(scheduled.comment.startsWith('@octocat '));
+    assert.ok(scheduled.comment.includes('development checklist'));
+    assert.ok(scheduled.comment.includes('separate library on PyPI'));
+    assert.ok(scheduled.comment.includes('quality-scale rules'));
+    assert.ok(scheduled.comment.includes('single platform'));
+  });
+
+  it('does nothing for a label we have no context for', async () => {
+    const context = makeContext('bugfix');
+
+    await handler.handle(context);
+
+    assert.strictEqual(context.scheduledComments.length, 0);
+  });
+});

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -130,6 +130,7 @@ describe('GithubWebhookModule', () => {
         'DocsMissing',
         'NewIntegrationsHandler',
         'PlatinumReview',
+        'PrContext',
         'QualityScaleLabeler',
         'RequiredLabels',
         'ValidateCla',


### PR DESCRIPTION
## What

Adds a `PrContext` handler that posts per-label guidance when a **core** pull
request is labeled. Ships one entry — `new-integration` — pointing the author at
the development checklist, the library requirement, the Bronze quality scale and
the single-platform guideline, so they can self-check while the PR waits for
review.

Mirrors the existing `IssueContext` handler (label → comment); the message is
kept inline as a small map, matching how `new_integrations.ts` holds its message
text, so there is no extra data file for a single entry.

## The comment (new-integration)

> Thanks for the contribution! While this waits for review, it may help to
> self-check a few things reviewers will look at:
>
> - **Docs**: does it follow the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)? In particular, all device/API communication should live in a [separate library on PyPI](https://developers.home-assistant.io/docs/creating_component_code_review) referenced in the manifest, not inside the integration.
> - **Quality scale**: since this targets Bronze, going through the [quality-scale rules](https://developers.home-assistant.io/docs/integration_quality_scale_index/) and ticking them off in `quality_scale.yaml` avoids surprises later.
> - **Scope**: a new integration should add a single platform to keep the PR small and reviewable — further platforms can follow in separate PRs.

## Notes

- Core only, on `pull_request.labeled`.
- Tests cover the new-integration comment and the no-op for other labels.
