### PR TITLE
Retry commit statuses racing fork pushes and await CLA status posts

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.const.ts
+++ b/services/bots/src/github-webhook/github-webhook.const.ts
@@ -17,6 +17,10 @@ export type GetIssueLabelResponse =
   RestEndpointMethodTypes['issues']['getLabel']['response']['data'];
 export type PullRequestCreateReviewParams =
   RestEndpointMethodTypes['pulls']['createReview']['parameters'];
+export type CreateCommitStatusParams =
+  RestEndpointMethodTypes['repos']['createCommitStatus']['parameters'];
+export type CreateCommitStatusResponse =
+  RestEndpointMethodTypes['repos']['createCommitStatus']['response'];
 
 export type Repository = HomeAssistantRepository | ESPHomeRepository;
 

--- a/services/bots/src/github-webhook/github-webhook.model.ts
+++ b/services/bots/src/github-webhook/github-webhook.model.ts
@@ -1,5 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import {
+  CreateCommitStatusParams,
+  CreateCommitStatusResponse,
   EventType,
   GetIssueLabelParams,
   GetIssueLabelResponse,
@@ -23,6 +25,34 @@ export class GithubClient extends Octokit {
     } catch (_err) {
       // Sometimes Github responds with 404 directly,
       // sometimes it does not, and only changes the response.status to 404
+    }
+  }
+
+  async createCommitStatusWithRetry(
+    params: CreateCommitStatusParams,
+    options: { retries?: number; backoffMs?: number } = {},
+  ): Promise<CreateCommitStatusResponse | undefined> {
+    const { retries = 3, backoffMs = 1_000 } = options;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await this.repos.createCommitStatus(params);
+      } catch (err) {
+        // Right after a push to a fork, the pull_request webhook can fire before the new
+        // commit is reachable in the base repository, making GitHub reject the status
+        // with 422 "No commit found for SHA" even though the commit exists.
+        if (err?.status !== 422 || !err?.message?.includes('No commit found for SHA')) {
+          throw err;
+        }
+        if (attempt >= retries) {
+          this.log.warn(
+            `Skipping status "${params.context}", commit ${params.sha} still not found after ${
+              retries + 1
+            } attempts`,
+          );
+          return undefined;
+        }
+        await new Promise((resolve) => setTimeout(resolve, backoffMs * 2 ** attempt));
+      }
     }
   }
 }

--- a/services/bots/src/github-webhook/handlers/blocking_labels.ts
+++ b/services/bots/src/github-webhook/handlers/blocking_labels.ts
@@ -27,7 +27,7 @@ export class BlockingLabels extends BaseWebhookHandler {
 
     for (const [label, description] of Object.entries(LabelsToCheck[context.repository] || {})) {
       const hasBlockingLabel = currentLabels.has(label);
-      await context.github.repos.createCommitStatus(
+      await context.github.createCommitStatusWithRetry(
         context.repo({
           sha: context.payload.pull_request.head.sha,
           context: `blocking-label-${label.toLowerCase().replace(' ', '-')}`,

--- a/services/bots/src/github-webhook/handlers/docs_missing.ts
+++ b/services/bots/src/github-webhook/handlers/docs_missing.ts
@@ -44,7 +44,7 @@ export class DocsMissing extends BaseWebhookHandler {
       needsDocumentation = linksToDocs.length === 0;
     }
 
-    await context.github.repos.createCommitStatus(
+    await context.github.createCommitStatusWithRetry(
       context.repo({
         sha: context.payload.pull_request.head.sha,
         context: 'docs-missing',

--- a/services/bots/src/github-webhook/handlers/platinum_review.ts
+++ b/services/bots/src/github-webhook/handlers/platinum_review.ts
@@ -67,7 +67,7 @@ export class PlatinumReview extends BaseWebhookHandler {
       }
     }
 
-    await context.github.repos.createCommitStatus(
+    await context.github.createCommitStatusWithRetry(
       context.repo({
         sha: context.payload.pull_request.head.sha,
         context: 'code-owner-approval',

--- a/services/bots/src/github-webhook/handlers/required_labels.ts
+++ b/services/bots/src/github-webhook/handlers/required_labels.ts
@@ -45,7 +45,7 @@ export class RequiredLabels extends BaseWebhookHandler {
 
     const hasRequiredLabels = requiredLabels.some((label) => currentLabels.has(label));
 
-    await context.github.repos.createCommitStatus(
+    await context.github.createCommitStatusWithRetry(
       context.repo({
         sha: context.payload.pull_request.head.sha,
         context: 'required-labels',

--- a/services/bots/src/github-webhook/handlers/validate-cla.ts
+++ b/services/bots/src/github-webhook/handlers/validate-cla.ts
@@ -132,16 +132,12 @@ export class ValidateCla extends BaseWebhookHandler {
 
       context.scheduleIssueLabel(ClaIssueLabel.CLA_ERROR);
 
-      commitsWithoutLogins.forEach((commit) => {
-        context.github.repos.createCommitStatus(
-          context.repo({
-            sha: commit.sha,
-            state: 'failure',
-            description: 'Commit(s) are missing a linked GitHub user.',
-            context: botContextName,
-          }),
-        );
-      });
+      await this.setCommitStatuses(
+        context,
+        commitsWithoutLogins.map((commit) => commit.sha),
+        'failure',
+        'Commit(s) are missing a linked GitHub user.',
+      );
       return;
     }
 
@@ -157,15 +153,11 @@ export class ValidateCla extends BaseWebhookHandler {
       );
       context.scheduleIssueLabel(ClaIssueLabel.CLA_NEEDED);
 
-      authorsNeedingCLA.forEach((entry) =>
-        context.github.repos.createCommitStatus(
-          context.repo({
-            sha: entry.sha,
-            state: 'failure',
-            description: 'At least one contributor needs to sign the CLA',
-            context: botContextName,
-          }),
-        ),
+      await this.setCommitStatuses(
+        context,
+        authorsNeedingCLA.map((entry) => entry.sha),
+        'failure',
+        'At least one contributor needs to sign the CLA',
       );
 
       const missingSign: { [key: string]: string[] } = {};
@@ -221,17 +213,38 @@ export class ValidateCla extends BaseWebhookHandler {
       // ignroe missing label
     }
 
-    commits.forEach((commit) => {
-      context.github.repos.createCommitStatus(
-        context.repo({
-          sha: commit.sha,
-          state: 'success',
-          description: `Everyone involved ${
-            allCommitsIgnored ? 'are ignored' : 'has signed the CLA'
-          }`,
-          context: botContextName,
-        }),
-      );
+    await this.setCommitStatuses(
+      context,
+      commits.map((commit) => commit.sha),
+      'success',
+      `Everyone involved ${allCommitsIgnored ? 'are ignored' : 'has signed the CLA'}`,
+    );
+  }
+
+  private async setCommitStatuses(
+    context: WebhookContext<PullRequestEventData>,
+    shas: string[],
+    state: 'success' | 'failure',
+    description: string,
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      shas.map((sha) =>
+        context.github.createCommitStatusWithRetry(
+          context.repo({
+            sha,
+            state,
+            description,
+            context: botContextName,
+          }),
+        ),
+      ),
+    );
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        context.github.log.warn(
+          `Could not set CLA commit status on ${shas[index]}: ${result.reason?.message}`,
+        );
+      }
     });
   }
 }

--- a/tests/services/bots/github-webhook/github_client.spec.ts
+++ b/tests/services/bots/github-webhook/github_client.spec.ts
@@ -1,0 +1,84 @@
+import { GithubClient } from '../../../../services/bots/src/github-webhook/github-webhook.model';
+
+const statusParams = {
+  owner: 'home-assistant',
+  repo: 'core',
+  sha: '3d0b15003d4c6e0029c5d5966f72d7efd4a26ee7',
+  context: 'required-labels',
+  state: 'success' as const,
+};
+
+const noCommitError = () =>
+  Object.assign(new Error('No commit found for SHA: 3d0b15003d4c6e0029c5d5966f72d7efd4a26ee7'), {
+    status: 422,
+  });
+
+describe('GithubClient.createCommitStatusWithRetry', () => {
+  let client: GithubClient;
+  let createCommitStatus: jest.Mock;
+
+  beforeEach(() => {
+    client = new GithubClient();
+    createCommitStatus = jest.fn();
+    // @ts-ignore partial mock
+    client.repos = { createCommitStatus };
+    // @ts-ignore partial mock
+    client.log = { warn: jest.fn() };
+  });
+
+  it('returns the response when the first attempt succeeds', async () => {
+    createCommitStatus.mockResolvedValue({ status: 201 });
+
+    const response = await client.createCommitStatusWithRetry(statusParams);
+
+    expect(response).toEqual({ status: 201 });
+    expect(createCommitStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the commit is not found yet and succeeds', async () => {
+    createCommitStatus
+      .mockRejectedValueOnce(noCommitError())
+      .mockRejectedValueOnce(noCommitError())
+      .mockResolvedValue({ status: 201 });
+
+    const response = await client.createCommitStatusWithRetry(statusParams, { backoffMs: 1 });
+
+    expect(response).toEqual({ status: 201 });
+    expect(createCommitStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up without throwing when the commit never becomes available', async () => {
+    createCommitStatus.mockRejectedValue(noCommitError());
+
+    const response = await client.createCommitStatusWithRetry(statusParams, {
+      retries: 2,
+      backoffMs: 1,
+    });
+
+    expect(response).toBeUndefined();
+    expect(createCommitStatus).toHaveBeenCalledTimes(3);
+    expect(client.log.warn).toHaveBeenCalled();
+  });
+
+  it('rethrows other errors without retrying', async () => {
+    createCommitStatus.mockRejectedValue(
+      Object.assign(new Error('You have exceeded a secondary rate limit.'), { status: 403 }),
+    );
+
+    await expect(client.createCommitStatusWithRetry(statusParams)).rejects.toThrow(
+      'secondary rate limit',
+    );
+    expect(createCommitStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows 422 errors that are not about missing commits', async () => {
+    createCommitStatus.mockRejectedValue(
+      Object.assign(new Error('Validation Failed'), { status: 422 }),
+    );
+
+    await expect(client.createCommitStatusWithRetry(statusParams)).rejects.toThrow(
+      'Validation Failed',
+    );
+    expect(createCommitStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/services/bots/github-webhook/handlers/blocking_labels.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/blocking_labels.spec.ts
@@ -15,11 +15,9 @@ import {
 describe('BlockingLabels', () => {
   let handler: BlockingLabels;
   let mockContext: WebhookContext<any>;
-  let createCommitStatusCall: any;
 
   beforeEach(function () {
     handler = new BlockingLabels();
-    createCommitStatusCall = {};
     mockContext = mockWebhookContext({
       payload: loadJsonFixture('pull_request.opened'),
       eventType: EventType.PULL_REQUEST_LABELED,

--- a/tests/services/bots/github-webhook/handlers/blocking_labels.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/blocking_labels.spec.ts
@@ -25,10 +25,8 @@ describe('BlockingLabels', () => {
       eventType: EventType.PULL_REQUEST_LABELED,
       // @ts-ignore partial mock
       github: {
-        repos: {
-          // @ts-ignore partial mock
-          createCommitStatus: jest.fn(),
-        },
+        // @ts-ignore partial mock
+        createCommitStatusWithRetry: jest.fn(),
       },
     });
   });
@@ -45,7 +43,7 @@ describe('BlockingLabels', () => {
           mockContext.repository = repository as Repository;
           await handler.handle(mockContext);
 
-          expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith(
+          expect(mockContext.github.createCommitStatusWithRetry).toHaveBeenCalledWith(
             expect.objectContaining({
               context: `blocking-label-${label.toLowerCase().replace(' ', '-')}`,
               description,

--- a/tests/services/bots/github-webhook/handlers/docs_missing.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/docs_missing.spec.ts
@@ -8,18 +8,14 @@ import { loadJsonFixture } from '../../../../utils/fixture';
 describe('DocsMissing', () => {
   let handler: DocsMissing;
   let mockContext: WebhookContext<any>;
-  let createCommitStatusContents: any;
 
   beforeEach(function () {
     handler = new DocsMissing();
-    createCommitStatusContents = {};
     mockContext = mockWebhookContext({
       eventType: 'pull_request.labeled',
       payload: loadJsonFixture('pull_request.opened', {}),
       github: {
-        async createCommitStatusWithRetry(params: any) {
-          createCommitStatusContents = params;
-        },
+        createCommitStatusWithRetry: jest.fn(),
       },
     });
   });

--- a/tests/services/bots/github-webhook/handlers/docs_missing.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/docs_missing.spec.ts
@@ -17,23 +17,21 @@ describe('DocsMissing', () => {
       eventType: 'pull_request.labeled',
       payload: loadJsonFixture('pull_request.opened', {}),
       github: {
-        repos: {
-          async createCommitStatus(params: any) {
-            createCommitStatusContents = params;
-          },
+        async createCommitStatusWithRetry(params: any) {
+          createCommitStatusContents = params;
         },
       },
     });
   });
 
   it('PR targeting master branch should auto-approve docs check', async () => {
-    mockContext.github.repos.createCommitStatus = jest.fn();
+    mockContext.github.createCommitStatusWithRetry = jest.fn();
     // Override the base ref to target master
     mockContext.payload.pull_request.base.ref = 'master';
 
     await handler.handle(mockContext);
 
-    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+    expect(mockContext.github.createCommitStatusWithRetry).toHaveBeenCalledWith({
       owner: 'Codertocat',
       repo: 'Hello-World',
       sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
@@ -44,7 +42,7 @@ describe('DocsMissing', () => {
   });
 
   it('PR targeting dev branch should run docs check - no labels', async () => {
-    mockContext.github.repos.createCommitStatus = jest.fn();
+    mockContext.github.createCommitStatusWithRetry = jest.fn();
     // Override the base ref to target dev (non-master branch)
     mockContext.payload.pull_request.base.ref = 'dev';
     // Clear any existing labels
@@ -52,7 +50,7 @@ describe('DocsMissing', () => {
 
     await handler.handle(mockContext);
 
-    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+    expect(mockContext.github.createCommitStatusWithRetry).toHaveBeenCalledWith({
       owner: 'Codertocat',
       repo: 'Hello-World',
       sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
@@ -63,7 +61,7 @@ describe('DocsMissing', () => {
   });
 
   it('PR targeting dev branch with docs-missing label should fail', async () => {
-    mockContext.github.repos.createCommitStatus = jest.fn();
+    mockContext.github.createCommitStatusWithRetry = jest.fn();
     // Override the base ref to target dev (non-master branch)
     mockContext.payload.pull_request.base.ref = 'dev';
     // Add docs-missing label
@@ -71,7 +69,7 @@ describe('DocsMissing', () => {
 
     await handler.handle(mockContext);
 
-    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+    expect(mockContext.github.createCommitStatusWithRetry).toHaveBeenCalledWith({
       owner: 'Codertocat',
       repo: 'Hello-World',
       sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
@@ -82,7 +80,7 @@ describe('DocsMissing', () => {
   });
 
   it('PR targeting dev branch with new-integration label but no docs link should fail', async () => {
-    mockContext.github.repos.createCommitStatus = jest.fn();
+    mockContext.github.createCommitStatusWithRetry = jest.fn();
     // Override the base ref to target dev (non-master branch)
     mockContext.payload.pull_request.base.ref = 'dev';
     // Add new-integration label
@@ -92,7 +90,7 @@ describe('DocsMissing', () => {
 
     await handler.handle(mockContext);
 
-    expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith({
+    expect(mockContext.github.createCommitStatusWithRetry).toHaveBeenCalledWith({
       owner: 'Codertocat',
       repo: 'Hello-World',
       sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',

--- a/tests/services/bots/github-webhook/handlers/required_labels.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/required_labels.spec.ts
@@ -15,11 +15,9 @@ import {
 describe('RequiredLabels', () => {
   let handler: RequiredLabels;
   let mockContext: WebhookContext<any>;
-  let createCommitStatusCall: any;
 
   beforeEach(function () {
     handler = new RequiredLabels();
-    createCommitStatusCall = {};
     mockContext = mockWebhookContext({
       payload: loadJsonFixture('pull_request.opened'),
       eventType: EventType.PULL_REQUEST_LABELED,

--- a/tests/services/bots/github-webhook/handlers/required_labels.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/required_labels.spec.ts
@@ -25,10 +25,8 @@ describe('RequiredLabels', () => {
       eventType: EventType.PULL_REQUEST_LABELED,
       // @ts-ignore partial mock
       github: {
-        repos: {
-          // @ts-ignore partial mock
-          createCommitStatus: jest.fn(),
-        },
+        // @ts-ignore partial mock
+        createCommitStatusWithRetry: jest.fn(),
       },
     });
   });
@@ -42,7 +40,7 @@ describe('RequiredLabels', () => {
         mockContext.repository = repository as Repository;
         await handler.handle(mockContext);
 
-        expect(mockContext.github.repos.createCommitStatus).toHaveBeenCalledWith(
+        expect(mockContext.github.createCommitStatusWithRetry).toHaveBeenCalledWith(
           expect.objectContaining({
             context: 'required-labels',
             description: `Has at least one of the required labels (${lables.join(', ')})`,


### PR DESCRIPTION
## Problem

The bots service has been generating a steady stream of Sentry errors — `HttpError: No commit found for SHA: …` ([SERVICE-HUB-BOTS-39](https://home-assistant-io.sentry.io/issues/SERVICE-HUB-BOTS-39), 26k+ events since 2023) and `Error: Could not process webhook (No commit found for SHA: …)` ([SERVICE-HUB-BOTS-56](https://home-assistant-io.sentry.io/issues/SERVICE-HUB-BOTS-56) and siblings).

Investigation showed the commits are **not** deleted or force-pushed away — every SHA from recent events still exists in `home-assistant/core`. The real cause is a race: when a contributor pushes to their fork, the `pull_request.synchronize` webhook fires before the new commit is reachable in the base repository, so `POST /repos/…/statuses/{sha}` returns 422 "No commit found for SHA" even though the commit is visible seconds later. Verified against a live event: PR push at `13:39:22`, bot status call failing at `13:39:23`.

## Changes

- Add `GithubClient.createCommitStatusWithRetry()`: retries only this specific 422 with exponential backoff (1s/2s/4s, 4 attempts total). If the commit still isn't visible, it logs a warning and skips the status instead of throwing. All other errors propagate unchanged.
- Use it in every handler that posts commit statuses: `required_labels`, `blocking_labels`, `docs_missing`, `platinum_review`, `validate-cla`.
- `validate-cla` additionally posted its per-commit statuses without awaiting them, turning every failure (including GitHub secondary rate limits) into an unhandled promise rejection. Those posts are now collected with `Promise.allSettled` and failures are logged.

## Testing

- New `github_client.spec.ts` covering the retry behavior: first-try success, retry-then-recover, give-up-without-throwing, and rethrow of non-422 / unrelated-422 errors.
- Handler specs updated for the new method; full suite passes (21 suites, 159 tests).

The commit message includes `Fixes SERVICE-HUB-BOTS-39` / `Fixes SERVICE-HUB-BOTS-56` so Sentry resolves them on merge; the sibling issues (3G, 5B, 3P) share the same root cause and can be resolved manually afterwards.