### PR TITLE
Scope checks with enforcement of the rules for new integrations

### DIFF
--- a/services/bots/src/github-webhook/github-webhook.const.ts
+++ b/services/bots/src/github-webhook/github-webhook.const.ts
@@ -61,6 +61,7 @@ export enum EventType {
   PULL_REQUEST_OPENED = 'pull_request.opened',
   PULL_REQUEST_REOPENED = 'pull_request.reopened',
   PULL_REQUEST_READY_FOR_REVIEW = 'pull_request.ready_for_review',
+  PULL_REQUEST_REVIEW_REQUESTED = 'pull_request.review_requested',
   PULL_REQUEST_REVIEW_SUBMITTED = 'pull_request_review.submitted',
   PULL_REQUEST_SYNCHRONIZE = 'pull_request.synchronize',
   PULL_REQUEST_UNLABELED = 'pull_request.unlabeled',

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -116,11 +116,16 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     const integrationType = manifest['integration_type'];
     const requirements = manifest['requirements'];
     const hasRequirements = Array.isArray(requirements) && requirements.length > 0;
+    // `calculated` is the one hassfest-supported iot_class that doesn't imply any
+    // external communication (it derives state from data HA already has), see
+    // https://github.com/home-assistant/core/blob/dev/script/hassfest/manifest.py
+    const isCalculated = manifest['iot_class'] === 'calculated';
 
     if (
       typeof integrationType === 'string' &&
       EXTERNAL_DEPENDENCY_INTEGRATION_TYPES.has(integrationType) &&
-      !hasRequirements
+      !hasRequirements &&
+      !isCalculated
     ) {
       return `This integration communicates with a device or service (\`integration_type: "${integrationType}"\`) but \`manifest.json\` has no \`requirements\`. Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#22-manifest-manifestjson), communication code must be published as a separate PyPI library and listed under \`requirements\`, not embedded directly in the integration.`;
     }

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -1,4 +1,4 @@
-import { PullRequestLabeledEvent } from '@octokit/webhooks-types';
+import { PullRequestLabeledEvent, PullRequestReadyForReviewEvent } from '@octokit/webhooks-types';
 import yaml from 'js-yaml';
 import { EventType, HomeAssistantRepository } from '../github-webhook.const';
 import { WebhookContext } from '../github-webhook.model';
@@ -6,6 +6,8 @@ import { BaseWebhookHandler } from './base';
 
 import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
 import { ParsedPath } from '../utils/parse_path';
+
+type NewIntegrationEvent = PullRequestLabeledEvent | PullRequestReadyForReviewEvent;
 
 const REQUIRED_MANIFEST_FIELDS = ['domain', 'name', 'codeowners'];
 
@@ -54,7 +56,10 @@ const getRuleStatus = (value: unknown): RuleStatus => {
 };
 
 export class NewIntegrationsHandler extends BaseWebhookHandler {
-  public allowedEventTypes = [EventType.PULL_REQUEST_LABELED];
+  public allowedEventTypes = [
+    EventType.PULL_REQUEST_LABELED,
+    EventType.PULL_REQUEST_READY_FOR_REVIEW,
+  ];
   public allowedRepositories = [HomeAssistantRepository.CORE];
 
   private getTestsIssue(parsed: ParsedPath[]): string | undefined {
@@ -66,7 +71,7 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
   }
 
   private async getManifestIssue(
-    context: WebhookContext<PullRequestLabeledEvent>,
+    context: WebhookContext<NewIntegrationEvent>,
     parsed: ParsedPath[],
   ): Promise<string | undefined> {
     const manifestFile = parsed.find(
@@ -118,7 +123,7 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
   }
 
   private async getQualityScaleIssue(
-    context: WebhookContext<PullRequestLabeledEvent>,
+    context: WebhookContext<NewIntegrationEvent>,
     parsed: ParsedPath[],
   ): Promise<string | undefined> {
     const qualityScaleFile = parsed.find(
@@ -168,7 +173,7 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
   }
 
   private async getReconfigureFlowIssue(
-    context: WebhookContext<PullRequestLabeledEvent>,
+    context: WebhookContext<NewIntegrationEvent>,
     parsed: ParsedPath[],
   ): Promise<string | undefined> {
     const configFlowFile = parsed.find(
@@ -220,12 +225,19 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
   }
 
   /**
-   * When a new-integration label is added, check if the PR contains multiple platforms
-   * (entity or non-entity platforms such as diagnostics) or a brand sub-folder.
-   * If so, request changes with a combined message.
+   * When a new-integration label is added, or an author marks a new-integration PR
+   * ready for review, check it against the initial-PR scope rules. If any fail,
+   * request changes and (if the PR isn't already a draft) convert it back to draft --
+   * the author can't get it out of draft again until every check passes.
    */
-  async handle(context: WebhookContext<PullRequestLabeledEvent>) {
-    if (context.payload.label?.name !== 'new-integration') {
+  async handle(context: WebhookContext<NewIntegrationEvent>) {
+    if (context.eventType === EventType.PULL_REQUEST_LABELED) {
+      if ((context.payload as PullRequestLabeledEvent).label?.name !== 'new-integration') {
+        return;
+      }
+    } else if (
+      !context.payload.pull_request.labels?.some((label) => label.name === 'new-integration')
+    ) {
       return;
     }
 
@@ -252,5 +264,9 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
         event: 'REQUEST_CHANGES',
       }),
     );
+
+    if (!context.payload.pull_request.draft) {
+      await context.convertPullRequestToDraft(context.payload.pull_request.node_id);
+    }
   }
 }

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -1,4 +1,4 @@
-import { PullRequestLabeledEvent, PullRequestReadyForReviewEvent } from '@octokit/webhooks-types';
+import { PullRequestLabeledEvent, PullRequestReviewRequestedEvent } from '@octokit/webhooks-types';
 import yaml from 'js-yaml';
 import { EventType, HomeAssistantRepository } from '../github-webhook.const';
 import { WebhookContext } from '../github-webhook.model';
@@ -7,7 +7,13 @@ import { BaseWebhookHandler } from './base';
 import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
 import { ParsedPath } from '../utils/parse_path';
 
-type NewIntegrationEvent = PullRequestLabeledEvent | PullRequestReadyForReviewEvent;
+type NewIntegrationEvent = PullRequestLabeledEvent | PullRequestReviewRequestedEvent;
+
+// Matches the check already used by WebhookContext.senderIsBot.
+const BOT_LOGIN = 'homeassistant';
+
+const REQUEST_RECHECK_NOTE =
+  "Once you believe you've addressed everything above, re-request a review from this bot (the ↻ icon next to its review in the Reviewers panel) to re-run these checks.";
 
 const REQUIRED_MANIFEST_FIELDS = ['domain', 'name', 'codeowners'];
 
@@ -58,7 +64,7 @@ const getRuleStatus = (value: unknown): RuleStatus => {
 export class NewIntegrationsHandler extends BaseWebhookHandler {
   public allowedEventTypes = [
     EventType.PULL_REQUEST_LABELED,
-    EventType.PULL_REQUEST_READY_FOR_REVIEW,
+    EventType.PULL_REQUEST_REVIEW_REQUESTED,
   ];
   public allowedRepositories = [HomeAssistantRepository.CORE];
 
@@ -225,20 +231,29 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
   }
 
   /**
-   * When a new-integration label is added, or an author marks a new-integration PR
-   * ready for review, check it against the initial-PR scope rules. If any fail,
-   * request changes and (if the PR isn't already a draft) convert it back to draft --
-   * the author can't get it out of draft again until every check passes.
+   * Runs the full new-integration scope check suite when the `new-integration` label
+   * is added (i.e. at PR creation), and again whenever the author explicitly
+   * re-requests a review from this bot. It deliberately does NOT re-check on every
+   * push or on ready-for-review -- re-requesting review is an explicit, human-timed
+   * signal ("I think I've addressed everything"), so a later regression (e.g. a
+   * second platform added after the PR passed once) doesn't get silently missed by
+   * an automatic draft/undraft cycle nobody asked for.
    */
   async handle(context: WebhookContext<NewIntegrationEvent>) {
     if (context.eventType === EventType.PULL_REQUEST_LABELED) {
       if ((context.payload as PullRequestLabeledEvent).label?.name !== 'new-integration') {
         return;
       }
-    } else if (
-      !context.payload.pull_request.labels?.some((label) => label.name === 'new-integration')
-    ) {
-      return;
+    } else {
+      const requestedReviewer = (
+        context.payload as { requested_reviewer?: { login: string; type: string } }
+      ).requested_reviewer;
+      if (requestedReviewer?.login !== BOT_LOGIN && requestedReviewer?.type !== 'Bot') {
+        return;
+      }
+      if (!context.payload.pull_request.labels?.some((label) => label.name === 'new-integration')) {
+        return;
+      }
     }
 
     const pullRequestFiles = await fetchPullRequestFilesFromContext(context);
@@ -260,7 +275,7 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
 
     await context.github.pulls.createReview(
       context.pullRequest({
-        body: issues.join('\n\n'),
+        body: `${issues.join('\n\n')}\n\n---\n${REQUEST_RECHECK_NOTE}`,
         event: 'REQUEST_CHANGES',
       }),
     );

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -1,4 +1,5 @@
 import { PullRequestLabeledEvent } from '@octokit/webhooks-types';
+import yaml from 'js-yaml';
 import { EventType, HomeAssistantRepository } from '../github-webhook.const';
 import { WebhookContext } from '../github-webhook.model';
 import { BaseWebhookHandler } from './base';
@@ -6,15 +7,221 @@ import { BaseWebhookHandler } from './base';
 import { fetchPullRequestFilesFromContext } from '../utils/pull_request';
 import { ParsedPath } from '../utils/parse_path';
 
+const REQUIRED_MANIFEST_FIELDS = ['domain', 'name', 'codeowners'];
+
+// integration_type values that mean "this talks to a real device/service",
+// see https://developers.home-assistant.io/docs/core/pr_review_guide#22-manifest-manifestjson
+const EXTERNAL_DEPENDENCY_INTEGRATION_TYPES = new Set(['device', 'hub', 'service']);
+
+// Bronze-tier rule names, straight from home-assistant/core's own validator:
+// https://github.com/home-assistant/core/blob/dev/script/hassfest/quality_scale.py
+export const BRONZE_QUALITY_SCALE_RULES = [
+  'action-setup',
+  'appropriate-polling',
+  'brands',
+  'common-modules',
+  'config-flow',
+  'config-flow-test-coverage',
+  'dependency-transparency',
+  'docs-actions',
+  'docs-conditions',
+  'docs-high-level-description',
+  'docs-installation-instructions',
+  'docs-removal-instructions',
+  'docs-triggers',
+  'entity-event-setup',
+  'entity-unique-id',
+  'has-entity-name',
+  'runtime-data',
+  'test-before-configure',
+  'test-before-setup',
+  'unique-config-entry',
+];
+
+// Gold-tier rules that are easy to over-build into an initial submission; flagged
+// (not blocked) so the author can justify keeping one if the integration needs it,
+// see https://developers.home-assistant.io/docs/core/pr_review_guide#21-scope
+const PREMATURE_GOLD_RULES = ['dynamic-devices', 'stale-devices'];
+
+type RuleStatus = 'done' | 'exempt' | 'todo' | undefined;
+
+const getRuleStatus = (value: unknown): RuleStatus => {
+  if (value === 'done' || value === 'exempt' || value === 'todo') {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    const status = (value as { status?: unknown }).status;
+    if (status === 'done' || status === 'exempt' || status === 'todo') {
+      return status;
+    }
+  }
+  return undefined;
+};
+
 export class NewIntegrationsHandler extends BaseWebhookHandler {
   public allowedEventTypes = [EventType.PULL_REQUEST_LABELED];
   public allowedRepositories = [HomeAssistantRepository.CORE];
 
+  private getTestsIssue(parsed: ParsedPath[]): string | undefined {
+    if (parsed.some((path) => path.type === 'test')) {
+      return undefined;
+    }
+
+    return 'This PR does not include any tests. New integrations require tests, see the [development checklist](https://developers.home-assistant.io/docs/development_checklist/) for details.';
+  }
+
+  private async getManifestIssue(
+    context: WebhookContext<PullRequestLabeledEvent>,
+    parsed: ParsedPath[],
+  ): Promise<string | undefined> {
+    const manifestFile = parsed.find(
+      (path) => path.type === 'component' && path.filename === 'manifest.json',
+    );
+
+    if (!manifestFile) {
+      return 'This PR is missing a `manifest.json` for the new integration. See the [manifest documentation](https://developers.home-assistant.io/docs/creating_integration_manifest/) for the required format.';
+    }
+
+    let manifest: Record<string, unknown>;
+    try {
+      const { data } = await context.github.repos.getContent(
+        context.repo({ path: manifestFile.path, ref: context.payload.pull_request.head.sha }),
+      );
+      manifest = JSON.parse(
+        Buffer.from((data as { content: string }).content, 'base64').toString(),
+      );
+    } catch (_) {
+      return 'Could not read `manifest.json` for this PR. Please make sure it is valid JSON.';
+    }
+
+    const missingFields = REQUIRED_MANIFEST_FIELDS.filter((field) => {
+      const value = manifest[field];
+      return value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
+    });
+
+    if (missingFields.length > 0) {
+      return `The \`manifest.json\` is missing required field(s): ${missingFields
+        .map((field) => `\`${field}\``)
+        .join(
+          ', ',
+        )}. See the [manifest documentation](https://developers.home-assistant.io/docs/creating_integration_manifest/) for details.`;
+    }
+
+    const integrationType = manifest['integration_type'];
+    const requirements = manifest['requirements'];
+    const hasRequirements = Array.isArray(requirements) && requirements.length > 0;
+
+    if (
+      typeof integrationType === 'string' &&
+      EXTERNAL_DEPENDENCY_INTEGRATION_TYPES.has(integrationType) &&
+      !hasRequirements
+    ) {
+      return `This integration communicates with a device or service (\`integration_type: "${integrationType}"\`) but \`manifest.json\` has no \`requirements\`. Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#22-manifest-manifestjson), communication code must be published as a separate PyPI library and listed under \`requirements\`, not embedded directly in the integration.`;
+    }
+
+    return undefined;
+  }
+
+  private async getQualityScaleIssue(
+    context: WebhookContext<PullRequestLabeledEvent>,
+    parsed: ParsedPath[],
+  ): Promise<string | undefined> {
+    const qualityScaleFile = parsed.find(
+      (path) => path.type === 'component' && path.filename === 'quality_scale.yaml',
+    );
+
+    if (!qualityScaleFile) {
+      return 'This PR is missing a `quality_scale.yaml` file. Every bronze-tier rule must be marked `done` or `exempt`. See the [quality scale docs](https://developers.home-assistant.io/docs/core/integration-quality-scale/) for the required format.';
+    }
+
+    let rules: Record<string, unknown>;
+    try {
+      const { data } = await context.github.repos.getContent(
+        context.repo({ path: qualityScaleFile.path, ref: context.payload.pull_request.head.sha }),
+      );
+      const parsedYaml = yaml.load(
+        Buffer.from((data as { content: string }).content, 'base64').toString(),
+      ) as { rules?: Record<string, unknown> };
+      rules = parsedYaml?.rules || {};
+    } catch (_) {
+      return 'Could not read or parse `quality_scale.yaml` for this PR. Please make sure it is valid YAML.';
+    }
+
+    const messages: string[] = [];
+
+    const incompleteRules = BRONZE_QUALITY_SCALE_RULES.filter(
+      (rule) => !['done', 'exempt'].includes(getRuleStatus(rules[rule])),
+    );
+    if (incompleteRules.length > 0) {
+      messages.push(
+        `\`quality_scale.yaml\` has bronze-tier rule(s) not marked \`done\` or \`exempt\`: ${incompleteRules
+          .map((rule) => `\`${rule}\``)
+          .join(
+            ', ',
+          )}. Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#23-quality-scale-quality_scaleyaml), every bronze rule must be addressed before an initial PR is ready for review.`,
+      );
+    }
+
+    const prematureGoldRules = PREMATURE_GOLD_RULES.filter(
+      (rule) => getRuleStatus(rules[rule]) === 'done',
+    );
+    if (prematureGoldRules.length > 0) {
+      messages.push(
+        `\`quality_scale.yaml\` marks gold-tier rule(s) ${prematureGoldRules
+          .map((rule) => `\`${rule}\``)
+          .join(
+            ', ',
+          )} as \`done\`. These are usually out of scope for an initial new-integration PR — if the integration doesn't genuinely need this from day one, please defer it to a follow-up PR. If it does (e.g. entities only appear after a delayed device announcement), just say so in the PR description.`,
+      );
+    }
+
+    return messages.length > 0 ? messages.join('\n\n') : undefined;
+  }
+
+  private getDiagnosticsIssue(parsed: ParsedPath[]): string | undefined {
+    const hasDiagnostics = parsed.some((path) => path.filename === 'diagnostics.py');
+
+    if (!hasDiagnostics) {
+      return undefined;
+    }
+
+    return 'Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#21-scope), `diagnostics.py` is a gold-level quality scale feature and should not be part of an initial new-integration PR. Please remove it and submit it as a follow-up PR once this one merges.';
+  }
+
+  private async getReconfigureFlowIssue(
+    context: WebhookContext<PullRequestLabeledEvent>,
+    parsed: ParsedPath[],
+  ): Promise<string | undefined> {
+    const configFlowFile = parsed.find(
+      (path) => path.type === 'component' && path.filename === 'config_flow.py',
+    );
+
+    if (!configFlowFile) {
+      return undefined;
+    }
+
+    let content: string;
+    try {
+      const { data } = await context.github.repos.getContent(
+        context.repo({ path: configFlowFile.path, ref: context.payload.pull_request.head.sha }),
+      );
+      content = Buffer.from((data as { content: string }).content, 'base64').toString();
+    } catch (_) {
+      // If we can't read config_flow.py, don't block the PR on our own fetch failure.
+      return undefined;
+    }
+
+    if (!/async_step_reconfigure/.test(content)) {
+      return undefined;
+    }
+
+    return 'Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#21-scope), a reconfigure flow (`async_step_reconfigure`) is a gold-level quality scale feature and should not be part of an initial new-integration PR. Please remove it and submit it as a follow-up PR once this one merges.';
+  }
+
   private getPlatformIssue(parsed: ParsedPath[]): string | undefined {
     const hasMultiplePlatforms =
-      parsed.filter(
-        (path) => path.type === 'platform' || path.type === 'non-entity-platform',
-      ).length > 1;
+      parsed.filter((path) => path.type === 'platform' || path.type === 'non-entity-platform')
+        .length > 1;
 
     if (!hasMultiplePlatforms) {
       return undefined;
@@ -46,10 +253,15 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     const pullRequestFiles = await fetchPullRequestFilesFromContext(context);
     const parsed = pullRequestFiles.map((file) => new ParsedPath(file));
 
-    const issueCheckers = [this.getPlatformIssue, this.getBrandIssue];
-    const issues = issueCheckers
-      .map((checker) => checker.call(this, parsed))
-      .filter((issue): issue is string => Boolean(issue));
+    const issues = [
+      this.getPlatformIssue(parsed),
+      this.getBrandIssue(parsed),
+      this.getTestsIssue(parsed),
+      this.getDiagnosticsIssue(parsed),
+      await this.getManifestIssue(context, parsed),
+      await this.getReconfigureFlowIssue(context, parsed),
+      await this.getQualityScaleIssue(context, parsed),
+    ].filter((issue): issue is string => Boolean(issue));
 
     if (issues.length === 0) {
       return;

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -137,6 +137,31 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
     context: WebhookContext<NewIntegrationEvent>,
     parsed: ParsedPath[],
   ): Promise<string | undefined> {
+    // Integrations declaring a special (non-scaled) tier -- "internal" being the one
+    // that actually shows up on new-integration PRs -- are exempt from the whole
+    // bronze/silver/gold/platinum system, so they legitimately have no quality_scale.yaml.
+    // Verified against real examples: backup/http/auth in home-assistant/core all
+    // declare `"quality_scale": "internal"` and none of them has this file.
+    const manifestFile = parsed.find(
+      (path) => path.type === 'component' && path.filename === 'manifest.json',
+    );
+    if (manifestFile) {
+      try {
+        const { data } = await context.github.repos.getContent(
+          context.repo({ path: manifestFile.path, ref: context.payload.pull_request.head.sha }),
+        );
+        const manifest = JSON.parse(
+          Buffer.from((data as { content: string }).content, 'base64').toString(),
+        );
+        if (manifest['quality_scale'] === 'internal') {
+          return undefined;
+        }
+      } catch (_) {
+        // If we can't read manifest.json here, fall through -- getManifestIssue
+        // already reports manifest read/parse failures separately.
+      }
+    }
+
     const qualityScaleFile = parsed.find(
       (path) => path.type === 'component' && path.filename === 'quality_scale.yaml',
     );

--- a/services/bots/src/github-webhook/handlers/new_integrations.ts
+++ b/services/bots/src/github-webhook/handlers/new_integrations.ts
@@ -38,11 +38,6 @@ export const BRONZE_QUALITY_SCALE_RULES = [
   'unique-config-entry',
 ];
 
-// Gold-tier rules that are easy to over-build into an initial submission; flagged
-// (not blocked) so the author can justify keeping one if the integration needs it,
-// see https://developers.home-assistant.io/docs/core/pr_review_guide#21-scope
-const PREMATURE_GOLD_RULES = ['dynamic-devices', 'stale-devices'];
-
 type RuleStatus = 'done' | 'exempt' | 'todo' | undefined;
 
 const getRuleStatus = (value: unknown): RuleStatus => {
@@ -147,35 +142,19 @@ export class NewIntegrationsHandler extends BaseWebhookHandler {
       return 'Could not read or parse `quality_scale.yaml` for this PR. Please make sure it is valid YAML.';
     }
 
-    const messages: string[] = [];
-
     const incompleteRules = BRONZE_QUALITY_SCALE_RULES.filter(
       (rule) => !['done', 'exempt'].includes(getRuleStatus(rules[rule])),
     );
-    if (incompleteRules.length > 0) {
-      messages.push(
-        `\`quality_scale.yaml\` has bronze-tier rule(s) not marked \`done\` or \`exempt\`: ${incompleteRules
-          .map((rule) => `\`${rule}\``)
-          .join(
-            ', ',
-          )}. Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#23-quality-scale-quality_scaleyaml), every bronze rule must be addressed before an initial PR is ready for review.`,
-      );
+
+    if (incompleteRules.length === 0) {
+      return undefined;
     }
 
-    const prematureGoldRules = PREMATURE_GOLD_RULES.filter(
-      (rule) => getRuleStatus(rules[rule]) === 'done',
-    );
-    if (prematureGoldRules.length > 0) {
-      messages.push(
-        `\`quality_scale.yaml\` marks gold-tier rule(s) ${prematureGoldRules
-          .map((rule) => `\`${rule}\``)
-          .join(
-            ', ',
-          )} as \`done\`. These are usually out of scope for an initial new-integration PR — if the integration doesn't genuinely need this from day one, please defer it to a follow-up PR. If it does (e.g. entities only appear after a delayed device announcement), just say so in the PR description.`,
-      );
-    }
-
-    return messages.length > 0 ? messages.join('\n\n') : undefined;
+    return `\`quality_scale.yaml\` has bronze-tier rule(s) not marked \`done\` or \`exempt\`: ${incompleteRules
+      .map((rule) => `\`${rule}\``)
+      .join(
+        ', ',
+      )}. Per the [PR review guide](https://developers.home-assistant.io/docs/core/pr_review_guide#23-quality-scale-quality_scaleyaml), every bronze rule must be addressed before an initial PR is ready for review.`;
   }
 
   private getDiagnosticsIssue(parsed: ParsedPath[]): string | undefined {

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -508,4 +508,118 @@ describe('NewIntegrationsHandler', () => {
     assert.strictEqual(call.event, 'REQUEST_CHANGES');
     assert.ok(call.body.includes('Could not read or parse `quality_scale.yaml`'));
   });
+
+  it('converts the PR to draft when checks fail and it is not already a draft', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    expect(mockContext.github.graphql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining('convertPullRequestToDraft'),
+      }),
+    );
+    expect(mockContext.github.graphql.mock.calls[0][0].query).toContain(
+      mockContext.payload.pull_request.node_id,
+    );
+  });
+
+  it('does not try to draft a PR that is already a draft', async () => {
+    mockContext.payload.pull_request.draft = true;
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    expect(mockContext.github.graphql).not.toHaveBeenCalled();
+  });
+
+  it('does not draft a PR whose checks all pass', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+    expect(mockContext.github.graphql).not.toHaveBeenCalled();
+  });
+
+  describe('ready_for_review', () => {
+    beforeEach(function () {
+      mockContext = mockWebhookContext({
+        eventType: 'pull_request.ready_for_review',
+        payload: loadJsonFixture('pull_request.opened', {
+          pull_request: { labels: [{ name: 'new-integration' }], draft: false },
+        }),
+        github: {
+          pulls: {
+            createReview: jest.fn(),
+          },
+          repos: {
+            getContent: jest.fn(defaultGetContent),
+          },
+        },
+      });
+    });
+
+    it('does nothing when the PR lacks the new-integration label', async () => {
+      mockContext.payload.pull_request.labels = [];
+      mockContext._prFilesCache = [
+        { filename: 'homeassistant/components/my_integration/__init__.py' },
+        { filename: 'homeassistant/components/my_integration/sensor.py' },
+        TEST_FILE,
+      ];
+
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+      expect(mockContext.github.graphql).not.toHaveBeenCalled();
+    });
+
+    it('re-drafts a new-integration PR marked ready for review while checks still fail', async () => {
+      mockContext._prFilesCache = [
+        { filename: 'homeassistant/components/my_integration/__init__.py' },
+        { filename: 'homeassistant/components/my_integration/sensor.py' },
+        TEST_FILE,
+      ];
+
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+      expect(mockContext.github.graphql).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.stringContaining('convertPullRequestToDraft'),
+        }),
+      );
+    });
+
+    it('leaves a new-integration PR ready for review when all checks pass', async () => {
+      mockContext._prFilesCache = [
+        { filename: 'homeassistant/components/my_integration/__init__.py' },
+        { filename: 'homeassistant/components/my_integration/sensor.py' },
+        { filename: MANIFEST_PATH },
+        { filename: QUALITY_SCALE_PATH },
+        TEST_FILE,
+      ];
+
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+      expect(mockContext.github.graphql).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -1,9 +1,47 @@
 // @ts-nocheck
 import * as assert from 'assert';
 import { WebhookContext } from '../../../../../services/bots/src/github-webhook/github-webhook.model';
-import { NewIntegrationsHandler } from '../../../../../services/bots/src/github-webhook/handlers/new_integrations';
+import {
+  BRONZE_QUALITY_SCALE_RULES,
+  NewIntegrationsHandler,
+} from '../../../../../services/bots/src/github-webhook/handlers/new_integrations';
 import { mockWebhookContext } from '../../../../utils/test_context';
 import { loadJsonFixture } from '../../../../utils/fixture';
+
+const MANIFEST_PATH = 'homeassistant/components/my_integration/manifest.json';
+const CONFIG_FLOW_PATH = 'homeassistant/components/my_integration/config_flow.py';
+const QUALITY_SCALE_PATH = 'homeassistant/components/my_integration/quality_scale.yaml';
+const TEST_FILE = { filename: 'tests/components/my_integration/test_sensor.py' };
+
+const manifestContentResponse = (manifest: Record<string, unknown>) => ({
+  data: { content: Buffer.from(JSON.stringify(manifest)).toString('base64') },
+});
+
+const yamlContentResponse = (yamlText: string) => ({
+  data: { content: Buffer.from(yamlText).toString('base64') },
+});
+
+const VALID_MANIFEST = {
+  domain: 'my_integration',
+  name: 'My Integration',
+  codeowners: ['@example'],
+};
+
+const buildBronzeQualityScaleYaml = (overrides: Record<string, string> = {}) =>
+  `rules:\n${BRONZE_QUALITY_SCALE_RULES.map(
+    (rule) => `  ${rule}: ${overrides[rule] ?? 'done'}`,
+  ).join('\n')}\n`;
+
+const VALID_QUALITY_SCALE_YAML = buildBronzeQualityScaleYaml();
+
+// Default path-aware `getContent`: manifest.json and quality_scale.yaml both
+// resolve to complete/valid content unless a test overrides it.
+const defaultGetContent = (params: { path: string }) => {
+  if (params.path === QUALITY_SCALE_PATH) {
+    return Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML));
+  }
+  return Promise.resolve(manifestContentResponse(VALID_MANIFEST));
+};
 
 describe('NewIntegrationsHandler', () => {
   let handler: NewIntegrationsHandler;
@@ -19,6 +57,9 @@ describe('NewIntegrationsHandler', () => {
       github: {
         pulls: {
           createReview: jest.fn(),
+        },
+        repos: {
+          getContent: jest.fn(defaultGetContent),
         },
       },
     });
@@ -37,10 +78,13 @@ describe('NewIntegrationsHandler', () => {
     expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
   });
 
-  it('does nothing when a new-integration PR has a single platform and no brand folder', async () => {
+  it('does nothing when a new-integration PR has a single platform, tests, a valid manifest and quality_scale.yaml', async () => {
     mockContext._prFilesCache = [
       { filename: 'homeassistant/components/my_integration/__init__.py' },
       { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
     ];
 
     await handler.handle(mockContext);
@@ -53,6 +97,9 @@ describe('NewIntegrationsHandler', () => {
       { filename: 'homeassistant/components/my_integration/__init__.py' },
       { filename: 'homeassistant/components/my_integration/sensor.py' },
       { filename: 'homeassistant/components/my_integration/climate.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
     ];
 
     await handler.handle(mockContext);
@@ -69,6 +116,9 @@ describe('NewIntegrationsHandler', () => {
       { filename: 'homeassistant/components/my_integration/__init__.py' },
       { filename: 'homeassistant/components/my_integration/sensor.py' },
       { filename: 'homeassistant/components/my_integration/diagnostics.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
     ];
 
     await handler.handle(mockContext);
@@ -81,9 +131,14 @@ describe('NewIntegrationsHandler', () => {
   });
 
   it('does nothing when a new-integration PR has only a single non-entity platform', async () => {
+    // Uses `intent.py` rather than `diagnostics.py` here since diagnostics.py is
+    // separately (and unconditionally) flagged by getDiagnosticsIssue below.
     mockContext._prFilesCache = [
       { filename: 'homeassistant/components/my_integration/__init__.py' },
-      { filename: 'homeassistant/components/my_integration/diagnostics.py' },
+      { filename: 'homeassistant/components/my_integration/intent.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
     ];
 
     await handler.handle(mockContext);
@@ -97,6 +152,9 @@ describe('NewIntegrationsHandler', () => {
       { filename: 'homeassistant/components/my_integration/sensor.py' },
       { filename: 'homeassistant/components/my_integration/brand/icon.png' },
       { filename: 'homeassistant/components/my_integration/brand/logo.png' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
     ];
 
     await handler.handle(mockContext);
@@ -117,6 +175,9 @@ describe('NewIntegrationsHandler', () => {
       { filename: 'homeassistant/components/my_integration/sensor.py' },
       { filename: 'homeassistant/components/my_integration/climate.py' },
       { filename: 'homeassistant/components/my_integration/brand/icon.png' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
     ];
 
     await handler.handle(mockContext);
@@ -129,5 +190,366 @@ describe('NewIntegrationsHandler', () => {
     assert.ok(
       call.body.includes('https://developers.home-assistant.io/docs/core/integration/brand_images'),
     );
+  });
+
+  it('requests changes when the PR has no tests', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('does not include any tests'));
+  });
+
+  it('requests changes when manifest.json is missing', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('missing a `manifest.json`'));
+  });
+
+  it('requests changes when manifest.json is missing required fields', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML))
+        : Promise.resolve(manifestContentResponse({ domain: 'my_integration' })),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('`name`'));
+    assert.ok(call.body.includes('`codeowners`'));
+    assert.ok(!call.body.includes('`domain`'));
+  });
+
+  it('requests changes when a device integration has no requirements', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML))
+        : Promise.resolve(
+            manifestContentResponse({ ...VALID_MANIFEST, integration_type: 'device' }),
+          ),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('no `requirements`'));
+  });
+
+  it('does nothing when a device integration has requirements set', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML))
+        : Promise.resolve(
+            manifestContentResponse({
+              ...VALID_MANIFEST,
+              integration_type: 'device',
+              requirements: ['my_integration_lib==1.0.0'],
+            }),
+          ),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when a non-device integration (e.g. helper) has no requirements', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML))
+        : Promise.resolve(
+            manifestContentResponse({ ...VALID_MANIFEST, integration_type: 'helper' }),
+          ),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
+  it('requests changes when the PR includes diagnostics.py', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: 'homeassistant/components/my_integration/diagnostics.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('`diagnostics.py`'));
+  });
+
+  it('requests changes when config_flow.py implements a reconfigure flow', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) => {
+      if (params.path === CONFIG_FLOW_PATH) {
+        return Promise.resolve({
+          data: {
+            content: Buffer.from(
+              'async def async_step_reconfigure(self, user_input=None):\n    pass',
+            ).toString('base64'),
+          },
+        });
+      }
+      if (params.path === QUALITY_SCALE_PATH) {
+        return Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML));
+      }
+      return Promise.resolve(manifestContentResponse(VALID_MANIFEST));
+    });
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: CONFIG_FLOW_PATH },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('reconfigure flow'));
+  });
+
+  it('does nothing when config_flow.py has no reconfigure flow', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) => {
+      if (params.path === CONFIG_FLOW_PATH) {
+        return Promise.resolve({
+          data: {
+            content: Buffer.from(
+              'async def async_step_user(self, user_input=None):\n    pass',
+            ).toString('base64'),
+          },
+        });
+      }
+      if (params.path === QUALITY_SCALE_PATH) {
+        return Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML));
+      }
+      return Promise.resolve(manifestContentResponse(VALID_MANIFEST));
+    });
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: CONFIG_FLOW_PATH },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
+  it('requests changes when manifest.json is not valid JSON', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML))
+        : Promise.resolve({ data: { content: Buffer.from('not json').toString('base64') } }),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('Could not read `manifest.json`'));
+  });
+
+  it('requests changes when quality_scale.yaml is missing', async () => {
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('missing a `quality_scale.yaml`'));
+  });
+
+  it('requests changes when a bronze rule is marked todo', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(
+            yamlContentResponse(
+              buildBronzeQualityScaleYaml({ 'config-flow-test-coverage': 'todo' }),
+            ),
+          )
+        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('`config-flow-test-coverage`'));
+  });
+
+  it('does nothing when a bronze rule is marked exempt with a reason', async () => {
+    const yamlText = `rules:\n${BRONZE_QUALITY_SCALE_RULES.map((rule) =>
+      rule === 'action-setup'
+        ? `  ${rule}:\n    status: exempt\n    comment: no actions in this integration`
+        : `  ${rule}: done`,
+    ).join('\n')}\n`;
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(yamlText))
+        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
+  it('requests changes when dynamic-devices or stale-devices is marked done', async () => {
+    const yamlText = `${VALID_QUALITY_SCALE_YAML}  dynamic-devices: done\n  stale-devices: done\n`;
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(yamlText))
+        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('`dynamic-devices`'));
+    assert.ok(call.body.includes('`stale-devices`'));
+  });
+
+  it('does nothing when dynamic-devices is marked todo (not yet built)', async () => {
+    const yamlText = `${VALID_QUALITY_SCALE_YAML}  dynamic-devices: todo\n`;
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(yamlText))
+        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
+  it('requests changes when quality_scale.yaml is not valid YAML', async () => {
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(':\n  not: [valid'))
+        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+    assert.strictEqual(call.event, 'REQUEST_CHANGES');
+    assert.ok(call.body.includes('Could not read or parse `quality_scale.yaml`'));
   });
 });

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -487,50 +487,6 @@ describe('NewIntegrationsHandler', () => {
     expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
   });
 
-  it('requests changes when dynamic-devices or stale-devices is marked done', async () => {
-    const yamlText = `${VALID_QUALITY_SCALE_YAML}  dynamic-devices: done\n  stale-devices: done\n`;
-    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
-      params.path === QUALITY_SCALE_PATH
-        ? Promise.resolve(yamlContentResponse(yamlText))
-        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
-    );
-    mockContext._prFilesCache = [
-      { filename: 'homeassistant/components/my_integration/__init__.py' },
-      { filename: 'homeassistant/components/my_integration/sensor.py' },
-      { filename: MANIFEST_PATH },
-      { filename: QUALITY_SCALE_PATH },
-      TEST_FILE,
-    ];
-
-    await handler.handle(mockContext);
-
-    expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
-    const call = mockContext.github.pulls.createReview.mock.calls[0][0];
-    assert.strictEqual(call.event, 'REQUEST_CHANGES');
-    assert.ok(call.body.includes('`dynamic-devices`'));
-    assert.ok(call.body.includes('`stale-devices`'));
-  });
-
-  it('does nothing when dynamic-devices is marked todo (not yet built)', async () => {
-    const yamlText = `${VALID_QUALITY_SCALE_YAML}  dynamic-devices: todo\n`;
-    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
-      params.path === QUALITY_SCALE_PATH
-        ? Promise.resolve(yamlContentResponse(yamlText))
-        : Promise.resolve(manifestContentResponse(VALID_MANIFEST)),
-    );
-    mockContext._prFilesCache = [
-      { filename: 'homeassistant/components/my_integration/__init__.py' },
-      { filename: 'homeassistant/components/my_integration/sensor.py' },
-      { filename: MANIFEST_PATH },
-      { filename: QUALITY_SCALE_PATH },
-      TEST_FILE,
-    ];
-
-    await handler.handle(mockContext);
-
-    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
-  });
-
   it('requests changes when quality_scale.yaml is not valid YAML', async () => {
     mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
       params.path === QUALITY_SCALE_PATH

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -558,12 +558,13 @@ describe('NewIntegrationsHandler', () => {
     expect(mockContext.github.graphql).not.toHaveBeenCalled();
   });
 
-  describe('ready_for_review', () => {
+  describe('review_requested', () => {
     beforeEach(function () {
       mockContext = mockWebhookContext({
-        eventType: 'pull_request.ready_for_review',
+        eventType: 'pull_request.review_requested',
         payload: loadJsonFixture('pull_request.opened', {
-          pull_request: { labels: [{ name: 'new-integration' }], draft: false },
+          requested_reviewer: { login: 'homeassistant', type: 'Bot' },
+          pull_request: { labels: [{ name: 'new-integration' }] },
         }),
         github: {
           pulls: {
@@ -574,6 +575,20 @@ describe('NewIntegrationsHandler', () => {
           },
         },
       });
+    });
+
+    it('does nothing when the requested reviewer is not this bot', async () => {
+      mockContext.payload.requested_reviewer = { login: 'some-human', type: 'User' };
+      mockContext._prFilesCache = [
+        { filename: 'homeassistant/components/my_integration/__init__.py' },
+        { filename: 'homeassistant/components/my_integration/sensor.py' },
+        TEST_FILE,
+      ];
+
+      await handler.handle(mockContext);
+
+      expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+      expect(mockContext.github.graphql).not.toHaveBeenCalled();
     });
 
     it('does nothing when the PR lacks the new-integration label', async () => {
@@ -590,7 +605,7 @@ describe('NewIntegrationsHandler', () => {
       expect(mockContext.github.graphql).not.toHaveBeenCalled();
     });
 
-    it('re-drafts a new-integration PR marked ready for review while checks still fail', async () => {
+    it('re-checks and re-drafts when the bot is re-requested for review and checks still fail', async () => {
       mockContext._prFilesCache = [
         { filename: 'homeassistant/components/my_integration/__init__.py' },
         { filename: 'homeassistant/components/my_integration/sensor.py' },
@@ -600,6 +615,8 @@ describe('NewIntegrationsHandler', () => {
       await handler.handle(mockContext);
 
       expect(mockContext.github.pulls.createReview).toHaveBeenCalledTimes(1);
+      const call = mockContext.github.pulls.createReview.mock.calls[0][0];
+      assert.ok(call.body.includes('re-request a review'));
       expect(mockContext.github.graphql).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.stringContaining('convertPullRequestToDraft'),
@@ -607,7 +624,7 @@ describe('NewIntegrationsHandler', () => {
       );
     });
 
-    it('leaves a new-integration PR ready for review when all checks pass', async () => {
+    it('does nothing when the bot is re-requested for review and all checks pass', async () => {
       mockContext._prFilesCache = [
         { filename: 'homeassistant/components/my_integration/__init__.py' },
         { filename: 'homeassistant/components/my_integration/sensor.py' },

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -466,6 +466,24 @@ describe('NewIntegrationsHandler', () => {
     assert.ok(call.body.includes('missing a `quality_scale.yaml`'));
   });
 
+  it('does nothing for a missing quality_scale.yaml when the integration is internal', async () => {
+    // Real-world case: home-assistant/core's backup/http/auth integrations all
+    // declare "quality_scale": "internal" and have no quality_scale.yaml at all.
+    mockContext.github.repos.getContent = jest
+      .fn()
+      .mockResolvedValue(manifestContentResponse({ ...VALID_MANIFEST, quality_scale: 'internal' }));
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
   it('requests changes when a bronze rule is marked todo', async () => {
     mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
       params.path === QUALITY_SCALE_PATH

--- a/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
+++ b/tests/services/bots/github-webhook/handlers/new_integrations.spec.ts
@@ -272,6 +272,35 @@ describe('NewIntegrationsHandler', () => {
     assert.ok(call.body.includes('no `requirements`'));
   });
 
+  it('does nothing when a service integration has no requirements but iot_class is calculated', async () => {
+    // Real-world case: home-assistant/core's collection_image integration is
+    // integration_type "service" with no requirements at all, exempted from
+    // dependency-transparency in its own quality_scale.yaml because it derives
+    // state from data HA already has rather than talking to anything external.
+    mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
+      params.path === QUALITY_SCALE_PATH
+        ? Promise.resolve(yamlContentResponse(VALID_QUALITY_SCALE_YAML))
+        : Promise.resolve(
+            manifestContentResponse({
+              ...VALID_MANIFEST,
+              integration_type: 'service',
+              iot_class: 'calculated',
+            }),
+          ),
+    );
+    mockContext._prFilesCache = [
+      { filename: 'homeassistant/components/my_integration/__init__.py' },
+      { filename: 'homeassistant/components/my_integration/sensor.py' },
+      { filename: MANIFEST_PATH },
+      { filename: QUALITY_SCALE_PATH },
+      TEST_FILE,
+    ];
+
+    await handler.handle(mockContext);
+
+    expect(mockContext.github.pulls.createReview).not.toHaveBeenCalled();
+  });
+
   it('does nothing when a device integration has requirements set', async () => {
     mockContext.github.repos.getContent = jest.fn((params: { path: string }) =>
       params.path === QUALITY_SCALE_PATH

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -66,7 +66,14 @@ describe('GithubWebhookModule', () => {
     },
     {
       eventType: EventType.PULL_REQUEST_READY_FOR_REVIEW,
-      handlers: ['NewIntegrationsHandler', 'ReviewDrafter'],
+      handlers: ['ReviewDrafter'],
+      payload: {
+        repository: { full_name: 'home-assistant/core', owner: { login: 'home-assistant' } },
+      },
+    },
+    {
+      eventType: EventType.PULL_REQUEST_REVIEW_REQUESTED,
+      handlers: ['NewIntegrationsHandler'],
       payload: {
         repository: { full_name: 'home-assistant/core', owner: { login: 'home-assistant' } },
       },

--- a/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
+++ b/tests/services/bots/github-webhook/verify_enabled_handlers.spec.ts
@@ -66,7 +66,7 @@ describe('GithubWebhookModule', () => {
     },
     {
       eventType: EventType.PULL_REQUEST_READY_FOR_REVIEW,
-      handlers: ['ReviewDrafter'],
+      handlers: ['NewIntegrationsHandler', 'ReviewDrafter'],
       payload: {
         repository: { full_name: 'home-assistant/core', owner: { login: 'home-assistant' } },
       },


### PR DESCRIPTION
## Proposed change

### What
This adds new checks for the Home Assistant bot for new integrations with the bot enforcing it instead of leaving it as just a suggestion.

There are already two existing checks from the bot. The `NewIntegrationsHandler` already checked new-integration PRs for a single platform and no embedded `brand/` folder.

### Why
These checks come straight from HA's own dev docs and human maintainers already enforce them by hand. Instead of a maintainer catching this during review and asking for changes themselves, a failing check now blocks the PR from leaving draft automatically. Without this, a maintainer would end up doing that same enforcement manually later anyway, so this just does it before it reaches them, saving them time.

### New checks

- Test flag: Checks if there are any files under `tests/components/<domain>/`.
- manifest.json completeness: requires `domain`, `name`, `codeowners` to be filled. Also requires `requirements` to be non-empty when `integration_type` is `device`/`hub`/`service`, since communication code is supposed to live in a published PyPI library, not embedded directly in the integration ([§2.2][pr-review-guide-22]).
- `quality_scale.yaml` bronze completeness: This requires the file to exist and every bronze-tier rule to be `done` or `exempt` ([§2.3][pr-review-guide-23]). The rule list is pulled from core's own [`script/hassfest/quality_scale.py`][hassfest-quality-scale], so it won't drift from what `hassfest` actually checks.
- No `diagnostics.py` and `reconfigure flow`: gold-tier features, explicitly named as out of scope for an initial PR in [§2.1][pr-review-guide-21].

### Rule enforcement

The bot currently leaves the existing checks as just suggestions which can be missed by a PR author or ignored, but the change here enforces them. As mentioned earlier: "a maintainer would end up doing that same enforcement manually later anyway, so this just does it before it reaches them, saving them time."

Now, when any check fails:

1. The bot still leaves the `REQUEST_CHANGES` review with specifics.
2. If the PR isn't already a draft, it converts it to draft (reusing the same
   `convertPullRequestToDraft` mutation `review_drafter.ts` already uses for
   human-requested changes).

This runs at two points:

- When the `new-integration` label is added (unchanged trigger).
- When the author re-requests a review **from this bot specifically**
  (`pull_request.review_requested`, new event type). Re-requesting review is
  already the natural "I think I've addressed everything" signal. The bot's
  own stale review shows a re-request icon, so each review now says so
  explicitly.

This does *not* re-check when the author marks the PR as `ready_for_review` or on every new commit: a one-time check on the ready-for-review transition would create a false sense of security (pass once, then add something out of scope later with nothing re-verifying it), and re-checking on every push risks a noisy draft/undraft cycle nobody asked for. The re-request-review is explicit and human-timed instead.

## Some important context
The open PR count on `home-assistant/core` is growing faster than review capacity can keep up with, here are some screenshots showing proof:
<img width="920" height="681" alt="Screenshot 2026-08-17 at 4 33 06 PM" src="https://github.com/user-attachments/assets/36e33de1-87fe-4437-bd78-a9b8b61bd242" />
<img width="1002" height="1395" alt="Screenshot 2026-08-17 at 4 33 01 PM" src="https://github.com/user-attachments/assets/cc6021b1-312a-4704-8705-e7094e9edac1" />
As shown in the photo this is the strongest evidence of AI use growing rapidly in HA's codebase. In a 2 year period from now claude is number 8 biggest contributor, but in a 3 month period its number 2, behind frenck who is the project's creator. But there's 2 important things here

1. As shown in the second photo if you notice carefully, claude's graph is lopsided on the right, it's a very unequal graph showing the growth is more sudden
2. This almost certainly undercounts real AI involvement: it only reflects commits that declared `Co-Authored-By: Claude`, and doesn't include Copilot (separately the number 8 contributor over 24 months) or any other AI tool like ChatGPT Codex. In fact, the commit history on this very PR says I did it all by myself, even though all of these commits were co-authored with Claude in reality.

I decided to personally review two PRs by myself: [#179103](https://github.com/home-assistant/core/pull/179103) (TrueNAS CE), [#179174](https://github.com/home-assistant/core/pull/179174) (JFL Alarm). Both of them had the gold quality extras violated, alongside having services which also violated another rule. Both also initially violated the platform rule until they saw the bot's suggestions showing that the expansion of enforcement can be effective.

I also had this problem in my own new integration submission. I violated many rules, and skipped over the bot's suggestion, which would've been enforced if it was in place [#173830](https://github.com/home-assistant/core/pull/173830).

## Something I want to note
I have [5 open PRs](https://github.com/search?q=is%3Apr+is%3Aopen+org%3Ahome-assistant+author%3Avemboy200+archived%3Afalse+sort%3Aupdated-desc&type=pullrequests) that violate a [5 Pr limit rule](https://developers.home-assistant.io/docs/review-process/#what-not-to-do) however I am opening this PR because of the visual explained below

```
PR spike grows --> 5-PR cap blocks the fix --> reviewers can't keep up, fix stays stuck
     ^                                                          |
     '----------------------------------------------------------'
```

Reviewers are working through the existing queue, but it seems like new PRs keep arriving faster than they can clear it, so the queue, including mine, doesn't move.

## Testing (I had Claude write this one mostly)

- `npx jest`, `npx eslint`, `npx prettier --check` all pass locally (28 tests on `NewIntegrationsHandler` alone, 154 in the full suite).
- Dry-ran the check logic (not the HTTP/webhook layer) against real file contents pulled from my own `powershades-full` branch, the pre-trim version of #173830 that actually violated several of these rules. Correctly flagged: diagnostics.py present, reconfigure flow present, two missing bronze rules in `quality_scale.yaml`. Confirmed miss: doesn't catch communication code embedded directly in the integration if an unrelated PyPI package is also listed as a requirement (documented above).
- **Not yet tested**: the live webhook path: `convertPullRequestToDraft` against real permissions, and the real `pull_request.review_requested` payload shape (`requested_reviewer.login`), since that needs a live GitHub App pointed at a real repo. [Fill in once done / note in PR if still outstanding.]

This is AI-assisted (Claude Code): this has been reviewed, understood, and tested locally before I opened this PR. Every rule enforced here traces to a specific line in the PR review guide or `hassfest`'s own rule list. If I couldn't find documentation backing a rule, I left it out or reverted it rather than guess. Yes I am fighting fire with fire here because I'm using AI to solve a problem caused by AI.

## Future plans
I have future plans to expand on HA's bot capabilities to further prevent the maintainers from needing to correct obvious mistakes cause by ai agents. This pr description is already long enough so I dont want to state exactly what it is for now.

## Sources:

- [PR review guide][pr-review-guide]
- [§2.1 Scope][pr-review-guide-21]
- [§2.2 Manifest][pr-review-guide-22]
- [§2.3 Quality scale][pr-review-guide-23]
- [hassfest quality_scale.py][hassfest-quality-scale]

[pr-review-guide]: https://developers.home-assistant.io/docs/core/pr_review_guide
[pr-review-guide-21]: https://developers.home-assistant.io/docs/core/pr_review_guide#21-scope
[pr-review-guide-22]: https://developers.home-assistant.io/docs/core/pr_review_guide#22-manifest-manifestjson
[pr-review-guide-23]: https://developers.home-assistant.io/docs/core/pr_review_guide#23-quality-scale-quality_scaleyaml
[hassfest-quality-scale]: https://github.com/home-assistant/core/blob/dev/script/hassfest/quality_scale.py