### PR TITLE
Filter My redirects on hidden instead of deprecated

### DIFF
--- a/services/bots/src/discord/commands/home-assistant/my.ts
+++ b/services/bots/src/discord/commands/home-assistant/my.ts
@@ -108,7 +108,7 @@ export class CommandHomeAssistantMy {
       await interaction.respond(
         focusedValue.length !== 0
           ? this.serviceHomeassistantMyRedirectData.data
-              .filter((redirect) => !redirect.deprecated)
+              .filter((redirect) => !redirect.hidden)
               .map((redirect) => ({
                 name: redirect.name,
                 value: redirect.redirect,

--- a/services/bots/src/discord/services/home-assistant/my-redirect-data.ts
+++ b/services/bots/src/discord/services/home-assistant/my-redirect-data.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 interface Redirect {
   redirect: string;
-  deprecated?: boolean;
+  hidden?: boolean;
   custom?: boolean;
   name: string;
   badge?: string;


### PR DESCRIPTION
my.home-assistant.io is replacing the `deprecated` flag in `redirect.json` with `hidden` (home-assistant/my.home-assistant.io#757): renamed redirects now live in a `legacy` object, and the only entry left to hide from users is the OAuth callback. Without this change the `/my` autocomplete would start offering `oauth` once that lands.