### PR TITLE
Add frontend blocking labels

### DIFF
--- a/services/bots/src/github-webhook/handlers/blocking_labels.ts
+++ b/services/bots/src/github-webhook/handlers/blocking_labels.ts
@@ -10,6 +10,10 @@ export const LabelsToCheck: {
     'awaiting-frontend': { message: 'This PR is awaiting changes to the frontend' },
   },
   [HomeAssistantRepository.FRONTEND]: {
+    Blocked: { message: 'This PR has a blocker that must be resolved before merging' },
+    'Do Not Review': { message: 'Review is on hold for this PR' },
+    'has-parent': { message: 'This PR is waiting for its parent PR to merge' },
+    'Needs UX': { message: 'This PR is awaiting UX review' },
     'wait for backend': { message: 'This PR is awaiting changes to the backend' },
   },
 };


### PR DESCRIPTION
Add the remaining frontend labels to Service Hub's existing blocking-label checks. This replaces the frontend blocking-label workflow, removed in https://github.com/home-assistant/frontend/pull/54064 once this change is merged and deployed.